### PR TITLE
Scaffold Playwright MCP server architecture

### DIFF
--- a/dotnet/mcp/Class1.cs
+++ b/dotnet/mcp/Class1.cs
@@ -1,5 +1,0 @@
-namespace PlaywrightMcpServer;
-
-public class Class1
-{
-}

--- a/dotnet/mcp/Configuration/CapabilityFilters.cs
+++ b/dotnet/mcp/Configuration/CapabilityFilters.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Linq;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Configuration;
+
+/// <summary>
+/// Applies capability-based filtering to the tool registry.
+/// </summary>
+public static class CapabilityFilters
+{
+    public static IReadOnlyCollection<IToolDefinition> FilterTools(
+        IEnumerable<IToolDefinition> tools,
+        CapabilitySettings settings)
+    {
+        if (tools is null)
+        {
+            return new List<IToolDefinition>();
+        }
+
+        IEnumerable<IToolDefinition> result = tools;
+
+        if (settings.IncludedTools is { Count: > 0 })
+        {
+            var allowed = settings.IncludedTools.ToHashSet();
+            result = result.Where(t => allowed.Contains(t.Name));
+        }
+
+        if (settings.ExcludedTools is { Count: > 0 })
+        {
+            var excluded = settings.ExcludedTools.ToHashSet();
+            result = result.Where(t => !excluded.Contains(t.Name));
+        }
+
+        return result.ToList();
+    }
+}

--- a/dotnet/mcp/Configuration/ConfigLoader.cs
+++ b/dotnet/mcp/Configuration/ConfigLoader.cs
@@ -1,0 +1,37 @@
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PlaywrightMcp.Configuration;
+
+/// <summary>
+/// Responsible for loading configuration from disk or other sources.
+/// </summary>
+public static class ConfigLoader
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public static async Task<FullConfig> LoadAsync(Stream? stream, CancellationToken cancellationToken = default)
+    {
+        if (stream is null)
+        {
+            return new FullConfig();
+        }
+
+        try
+        {
+            return (await JsonSerializer.DeserializeAsync<FullConfig>(stream, SerializerOptions, cancellationToken)
+                    .ConfigureAwait(false))
+                ?? new FullConfig();
+        }
+        catch (JsonException)
+        {
+            // Surface a deterministic configuration even if parsing fails.
+            return new FullConfig();
+        }
+    }
+}

--- a/dotnet/mcp/Configuration/ConfigModels.cs
+++ b/dotnet/mcp/Configuration/ConfigModels.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+
+namespace PlaywrightMcp.Configuration;
+
+/// <summary>
+/// Represents the root configuration consumed by the MCP server.
+/// </summary>
+public sealed class FullConfig
+{
+    public BrowserConfig Browser { get; init; } = new();
+    public SecretsConfig Secrets { get; init; } = new();
+    public CapabilitySettings Capabilities { get; init; } = new();
+}
+
+/// <summary>
+/// Browser related options for establishing a Playwright context.
+/// </summary>
+public sealed class BrowserConfig
+{
+    public string? Endpoint { get; init; }
+    public bool Headless { get; init; } = true;
+    public string? DefaultViewport { get; init; }
+}
+
+/// <summary>
+/// Sensitive values that should be redacted from logs and responses.
+/// </summary>
+public sealed class SecretsConfig
+{
+    public IReadOnlyCollection<string> SensitiveValues { get; init; } = new List<string>();
+}
+
+/// <summary>
+/// Controls which capabilities and tools are exposed by the MCP server.
+/// </summary>
+public sealed class CapabilitySettings
+{
+    public bool AllowFileSystem { get; init; }
+    public bool EnableTracing { get; init; }
+    public IReadOnlyCollection<string>? IncludedTools { get; init; }
+    public IReadOnlyCollection<string>? ExcludedTools { get; init; }
+}

--- a/dotnet/mcp/Core/BrowserServerBackend/BrowserServerBackend.cs
+++ b/dotnet/mcp/Core/BrowserServerBackend/BrowserServerBackend.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using PlaywrightMcp.Configuration;
+using PlaywrightMcp.Core.Context;
+using PlaywrightMcp.Core.Protocol;
+using PlaywrightMcp.Core.Runtime;
+using PlaywrightMcp.Core.Services;
+using PlaywrightMcp.Core.Utils;
+
+namespace PlaywrightMcp.Core.BrowserServerBackend;
+
+/// <summary>
+/// Coordinates tool execution and shared browser context lifecycle.
+/// </summary>
+public sealed class BrowserServerBackend
+{
+    private readonly ToolRegistry _toolRegistry;
+    private readonly ToolExecutionService _executionService;
+    private readonly BrowserContextFactory _contextFactory;
+    private readonly FullConfig _configuration;
+    private readonly TimeProvider _timeProvider;
+    private Context.Context? _context;
+
+    public BrowserServerBackend(
+        ToolRegistry toolRegistry,
+        ToolExecutionService executionService,
+        BrowserContextFactory contextFactory,
+        FullConfig configuration,
+        TimeProvider timeProvider)
+    {
+        _toolRegistry = toolRegistry;
+        _executionService = executionService;
+        _contextFactory = contextFactory;
+        _configuration = configuration;
+        _timeProvider = timeProvider;
+    }
+
+    public IReadOnlyCollection<IToolDefinition> ListTools() => _toolRegistry.GetTools();
+
+    public async Task<Response> ExecuteAsync(string name, JsonElement parameters, CancellationToken cancellationToken)
+    {
+        if (!_toolRegistry.TryGetTool(name, out var tool))
+        {
+            return Response.Empty;
+        }
+
+        var invocationContext = new ToolInvocationContext(await EnsureContextAsync().ConfigureAwait(false), _configuration, _timeProvider);
+        return await _executionService.ExecuteAsync(tool, invocationContext, parameters, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<Context.Context> EnsureContextAsync()
+    {
+        if (_context is null)
+        {
+            _context = await _contextFactory.CreateAsync().ConfigureAwait(false);
+        }
+
+        return _context;
+    }
+}

--- a/dotnet/mcp/Core/BrowserServerBackend/ToolInvocationContext.cs
+++ b/dotnet/mcp/Core/BrowserServerBackend/ToolInvocationContext.cs
@@ -1,0 +1,24 @@
+using PlaywrightMcp.Configuration;
+using PlaywrightMcp.Core.Context;
+using PlaywrightMcp.Core.Utils;
+
+namespace PlaywrightMcp.Core.BrowserServerBackend;
+
+/// <summary>
+/// Holds execution-wide services and state for a single tool invocation.
+/// </summary>
+public sealed class ToolInvocationContext
+{
+    public ToolInvocationContext(Context.Context browserContext, FullConfig configuration, TimeProvider timeProvider)
+    {
+        BrowserContext = browserContext;
+        Configuration = configuration;
+        TimeProvider = timeProvider;
+    }
+
+    public Context.Context BrowserContext { get; }
+
+    public FullConfig Configuration { get; }
+
+    public TimeProvider TimeProvider { get; }
+}

--- a/dotnet/mcp/Core/Context/BrowserContextFactory.cs
+++ b/dotnet/mcp/Core/Context/BrowserContextFactory.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+
+namespace PlaywrightMcp.Core.Context;
+
+/// <summary>
+/// Provides a minimal abstraction for creating browser contexts.
+/// </summary>
+public sealed class BrowserContextFactory
+{
+    public Task<Context> CreateAsync()
+    {
+        return Task.FromResult(new Context());
+    }
+}

--- a/dotnet/mcp/Core/Context/Context.cs
+++ b/dotnet/mcp/Core/Context/Context.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace PlaywrightMcp.Core.Context;
+
+/// <summary>
+/// Represents the lifecycle of a browser session handled by the MCP server.
+/// </summary>
+public sealed class Context
+{
+    private readonly List<Tab> _tabs = new();
+
+    public IReadOnlyList<Tab> Tabs => _tabs;
+
+    public Tab CreateTab(string id)
+    {
+        var tab = new Tab(id);
+        _tabs.Add(tab);
+        return tab;
+    }
+}

--- a/dotnet/mcp/Core/Context/Tab.cs
+++ b/dotnet/mcp/Core/Context/Tab.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+
+namespace PlaywrightMcp.Core.Context;
+
+/// <summary>
+/// Represents a single browser tab or page.
+/// </summary>
+public sealed class Tab
+{
+    private readonly List<string> _events = new();
+
+    public Tab(string id)
+    {
+        Id = id;
+    }
+
+    public string Id { get; }
+
+    public IReadOnlyList<string> Events => _events;
+
+    public void RecordEvent(string description)
+    {
+        if (!string.IsNullOrWhiteSpace(description))
+        {
+            _events.Add(description);
+        }
+    }
+}

--- a/dotnet/mcp/Core/Context/TabEvents.cs
+++ b/dotnet/mcp/Core/Context/TabEvents.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace PlaywrightMcp.Core.Context;
+
+/// <summary>
+/// Provides helper methods for projecting raw Playwright events into textual descriptions.
+/// </summary>
+public static class TabEvents
+{
+    public static IReadOnlyCollection<string> ToSummaries(Tab tab)
+    {
+        return tab.Events;
+    }
+}

--- a/dotnet/mcp/Core/Protocol/McpContracts.cs
+++ b/dotnet/mcp/Core/Protocol/McpContracts.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace PlaywrightMcp.Core.Protocol;
+
+/// <summary>
+/// Representation of the MCP protocol contracts shared between the server and host.
+/// </summary>
+public sealed record ListToolsResponse(IReadOnlyCollection<ToolSummary> Tools);
+
+public sealed record ToolSummary(string Name, string Description, ToolSchema Schema);
+
+public sealed record CallToolRequest(string Name, object? Arguments);
+
+public sealed record CallToolResponse(bool Success, IReadOnlyCollection<object> Blocks);
+
+public sealed record PingRequest(string Message);
+
+public sealed record PingResponse(string Message);

--- a/dotnet/mcp/Core/Protocol/ResponseSerializer.cs
+++ b/dotnet/mcp/Core/Protocol/ResponseSerializer.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using PlaywrightMcp.Core.Runtime;
+using PlaywrightMcp.Core.Utils;
+
+namespace PlaywrightMcp.Core.Protocol;
+
+/// <summary>
+/// Serializes runtime responses into protocol structures.
+/// </summary>
+public static class ResponseSerializer
+{
+    public static CallToolResponse Serialize(Response response)
+    {
+        var blocks = new List<object>();
+        foreach (var block in response.Blocks)
+        {
+            blocks.Add(SerializationHelpers.SerializeBlock(block));
+        }
+
+        return new CallToolResponse(response.Success, blocks);
+    }
+}

--- a/dotnet/mcp/Core/Protocol/ToolDefinition.cs
+++ b/dotnet/mcp/Core/Protocol/ToolDefinition.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using PlaywrightMcp.Core.BrowserServerBackend;
+using PlaywrightMcp.Core.Runtime;
+
+namespace PlaywrightMcp.Core.Protocol;
+
+/// <summary>
+/// Describes a tool that can be invoked through the MCP protocol.
+/// </summary>
+public interface IToolDefinition
+{
+    string Name { get; }
+    string Description { get; }
+    ToolSchema InputSchema { get; }
+
+    Task<Response> ExecuteAsync(ToolInvocationContext context, JsonElement parameters, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// A simple base implementation that derived tools can inherit from.
+/// </summary>
+public abstract class ToolDefinitionBase : IToolDefinition
+{
+    protected ToolDefinitionBase(string name, string description, ToolSchema schema)
+    {
+        Name = name;
+        Description = description;
+        InputSchema = schema;
+    }
+
+    public string Name { get; }
+
+    public string Description { get; }
+
+    public ToolSchema InputSchema { get; }
+
+    public abstract Task<Response> ExecuteAsync(ToolInvocationContext context, JsonElement parameters, CancellationToken cancellationToken);
+}

--- a/dotnet/mcp/Core/Protocol/ToolSchema.cs
+++ b/dotnet/mcp/Core/Protocol/ToolSchema.cs
@@ -1,0 +1,18 @@
+using System.Text.Json;
+
+namespace PlaywrightMcp.Core.Protocol;
+
+/// <summary>
+/// Represents the schema for tool parameters and response metadata.
+/// </summary>
+public sealed class ToolSchema
+{
+    public ToolSchema(JsonElement jsonSchema)
+    {
+        JsonSchema = jsonSchema;
+    }
+
+    public JsonElement JsonSchema { get; }
+
+    public static ToolSchema Empty => new(JsonDocument.Parse("{}").RootElement);
+}

--- a/dotnet/mcp/Core/Runtime/Response.cs
+++ b/dotnet/mcp/Core/Runtime/Response.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+namespace PlaywrightMcp.Core.Runtime;
+
+/// <summary>
+/// Represents the result of a tool invocation.
+/// </summary>
+public sealed class Response
+{
+    private readonly List<ResponseBlock> _blocks = new();
+
+    public bool Success { get; init; } = true;
+
+    public IReadOnlyList<ResponseBlock> Blocks => _blocks;
+
+    public IDictionary<string, object?> Metadata { get; } = new Dictionary<string, object?>();
+
+    public static Response Empty { get; } = new();
+
+    public void AddBlock(ResponseBlock block)
+    {
+        if (block is not null)
+        {
+            _blocks.Add(block);
+        }
+    }
+}

--- a/dotnet/mcp/Core/Runtime/ResponseBlocks.cs
+++ b/dotnet/mcp/Core/Runtime/ResponseBlocks.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace PlaywrightMcp.Core.Runtime;
+
+/// <summary>
+/// Base class for a structured block within a response payload.
+/// </summary>
+public abstract class ResponseBlock
+{
+    protected ResponseBlock(string kind)
+    {
+        Kind = kind;
+    }
+
+    public string Kind { get; }
+}
+
+public sealed class MarkdownBlock : ResponseBlock
+{
+    public MarkdownBlock(string text)
+        : base("markdown")
+    {
+        Text = text;
+    }
+
+    public string Text { get; }
+}
+
+public sealed class ImageBlock : ResponseBlock
+{
+    public ImageBlock(byte[] data, string mediaType)
+        : base("image")
+    {
+        Data = data;
+        MediaType = mediaType;
+    }
+
+    public byte[] Data { get; }
+
+    public string MediaType { get; }
+}
+
+public sealed class JsonBlock : ResponseBlock
+{
+    public JsonBlock(object value)
+        : base("json")
+    {
+        Value = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    public object Value { get; }
+}

--- a/dotnet/mcp/Core/Runtime/SecretRedactor.cs
+++ b/dotnet/mcp/Core/Runtime/SecretRedactor.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PlaywrightMcp.Core.Runtime;
+
+/// <summary>
+/// Provides simple utilities for removing secrets from logs and responses.
+/// </summary>
+public sealed class SecretRedactor
+{
+    private readonly IReadOnlyCollection<string> _sensitiveValues;
+
+    public SecretRedactor(IReadOnlyCollection<string> sensitiveValues)
+    {
+        _sensitiveValues = sensitiveValues ?? new List<string>();
+    }
+
+    public string Redact(string input)
+    {
+        if (string.IsNullOrEmpty(input) || _sensitiveValues.Count == 0)
+        {
+            return input;
+        }
+
+        return _sensitiveValues.Aggregate(input, (current, secret) =>
+            string.IsNullOrEmpty(secret) ? current : current.Replace(secret, "***"));
+    }
+}

--- a/dotnet/mcp/Core/Runtime/SnapshotBuilder.cs
+++ b/dotnet/mcp/Core/Runtime/SnapshotBuilder.cs
@@ -1,0 +1,18 @@
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PlaywrightMcp.Core.Runtime;
+
+/// <summary>
+/// Generates textual representations of the current browser state.
+/// </summary>
+public sealed class SnapshotBuilder
+{
+    public Task<string> BuildSnapshotAsync(string sourceDescription)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("# Snapshot");
+        builder.AppendLine(sourceDescription);
+        return Task.FromResult(builder.ToString());
+    }
+}

--- a/dotnet/mcp/Core/Services/SessionLog.cs
+++ b/dotnet/mcp/Core/Services/SessionLog.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace PlaywrightMcp.Core.Services;
+
+/// <summary>
+/// Maintains an in-memory history of tool invocations.
+/// </summary>
+public sealed class SessionLog
+{
+    private readonly List<string> _entries = new();
+
+    public void Add(string entry)
+    {
+        if (!string.IsNullOrWhiteSpace(entry))
+        {
+            _entries.Add(entry);
+        }
+    }
+
+    public IReadOnlyList<string> Entries => _entries;
+}

--- a/dotnet/mcp/Core/Services/ToolExecutionService.cs
+++ b/dotnet/mcp/Core/Services/ToolExecutionService.cs
@@ -1,0 +1,28 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using PlaywrightMcp.Core.BrowserServerBackend;
+using PlaywrightMcp.Core.Protocol;
+using PlaywrightMcp.Core.Runtime;
+
+namespace PlaywrightMcp.Core.Services;
+
+/// <summary>
+/// Executes tool calls and provides centralised error handling.
+/// </summary>
+public sealed class ToolExecutionService
+{
+    public async Task<Response> ExecuteAsync(
+        IToolDefinition tool,
+        ToolInvocationContext context,
+        JsonElement parameters,
+        CancellationToken cancellationToken)
+    {
+        if (tool is null)
+        {
+            return Response.Empty;
+        }
+
+        return await tool.ExecuteAsync(context, parameters, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/dotnet/mcp/Core/Services/ToolRegistry.cs
+++ b/dotnet/mcp/Core/Services/ToolRegistry.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Core.Services;
+
+/// <summary>
+/// Stores tool definitions exposed by the server.
+/// </summary>
+public sealed class ToolRegistry
+{
+    private readonly Dictionary<string, IToolDefinition> _tools = new();
+
+    public void RegisterTools(IEnumerable<IToolDefinition> tools)
+    {
+        foreach (var tool in tools)
+        {
+            _tools[tool.Name] = tool;
+        }
+    }
+
+    public IReadOnlyCollection<IToolDefinition> GetTools() => _tools.Values.ToList();
+
+    public bool TryGetTool(string name, out IToolDefinition tool) => _tools.TryGetValue(name, out tool!);
+}

--- a/dotnet/mcp/Core/Utils/LocatorParser.cs
+++ b/dotnet/mcp/Core/Utils/LocatorParser.cs
@@ -1,0 +1,9 @@
+namespace PlaywrightMcp.Core.Utils;
+
+/// <summary>
+/// Provides helper methods for working with Playwright locators.
+/// </summary>
+public static class LocatorParser
+{
+    public static string Normalize(string locator) => locator?.Trim() ?? string.Empty;
+}

--- a/dotnet/mcp/Core/Utils/PlaywrightExtensions.cs
+++ b/dotnet/mcp/Core/Utils/PlaywrightExtensions.cs
@@ -1,0 +1,12 @@
+namespace PlaywrightMcp.Core.Utils;
+
+/// <summary>
+/// Placeholder for extension methods over Playwright objects.
+/// </summary>
+public static class PlaywrightExtensions
+{
+    public static string Describe(this object? playwrightObject)
+    {
+        return playwrightObject?.ToString() ?? "(null)";
+    }
+}

--- a/dotnet/mcp/Core/Utils/SerializationHelpers.cs
+++ b/dotnet/mcp/Core/Utils/SerializationHelpers.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using PlaywrightMcp.Core.Runtime;
+
+namespace PlaywrightMcp.Core.Utils;
+
+public static class SerializationHelpers
+{
+    public static object SerializeBlock(ResponseBlock block) => block switch
+    {
+        MarkdownBlock markdown => new Dictionary<string, object>
+        {
+            ["kind"] = markdown.Kind,
+            ["text"] = markdown.Text
+        },
+        ImageBlock image => new Dictionary<string, object>
+        {
+            ["kind"] = image.Kind,
+            ["mediaType"] = image.MediaType,
+            ["data"] = Convert.ToBase64String(image.Data)
+        },
+        JsonBlock json => new Dictionary<string, object>
+        {
+            ["kind"] = json.Kind,
+            ["value"] = json.Value
+        },
+        _ => new Dictionary<string, object> { ["kind"] = block.Kind }
+    };
+}

--- a/dotnet/mcp/Core/Utils/TimeProvider.cs
+++ b/dotnet/mcp/Core/Utils/TimeProvider.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace PlaywrightMcp.Core.Utils;
+
+/// <summary>
+/// Provides testable access to the current time.
+/// </summary>
+public class TimeProvider
+{
+    public virtual DateTimeOffset GetUtcNow() => DateTimeOffset.UtcNow;
+}

--- a/dotnet/mcp/Server/HeartbeatService.cs
+++ b/dotnet/mcp/Server/HeartbeatService.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PlaywrightMcp.Server;
+
+/// <summary>
+/// Periodically notifies the host that the server is still alive.
+/// </summary>
+public sealed class HeartbeatService
+{
+    private readonly IMcpTransport _transport;
+
+    public HeartbeatService(IMcpTransport transport)
+    {
+        _transport = transport;
+    }
+
+    public Task SendAsync(CancellationToken cancellationToken)
+    {
+        var heartbeat = new { type = "heartbeat" };
+        return _transport.WriteAsync(heartbeat, cancellationToken);
+    }
+}

--- a/dotnet/mcp/Server/IMcpTransport.cs
+++ b/dotnet/mcp/Server/IMcpTransport.cs
@@ -1,0 +1,14 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PlaywrightMcp.Server;
+
+/// <summary>
+/// Abstraction for the transport layer used by the MCP server.
+/// </summary>
+public interface IMcpTransport
+{
+    Task WriteAsync(object message, CancellationToken cancellationToken);
+
+    Task<object?> ReadAsync(CancellationToken cancellationToken);
+}

--- a/dotnet/mcp/Server/McpServer.cs
+++ b/dotnet/mcp/Server/McpServer.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using PlaywrightMcp.Core.BrowserServerBackend;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Server;
+
+/// <summary>
+/// Entry point exposing the MCP server functionality.
+/// </summary>
+public sealed class McpServer
+{
+    private readonly BrowserServerBackend _backend;
+    private readonly IMcpTransport _transport;
+
+    public McpServer(BrowserServerBackend backend, IMcpTransport transport)
+    {
+        _backend = backend;
+        _transport = transport;
+    }
+
+    public Task<ListToolsResponse> ListToolsAsync(CancellationToken cancellationToken = default)
+    {
+        var summaries = _backend.ListTools()
+            .Select(t => new ToolSummary(t.Name, t.Description, t.InputSchema))
+            .ToList();
+        return Task.FromResult(new ListToolsResponse(summaries));
+    }
+
+    public async Task<CallToolResponse> CallToolAsync(string name, JsonElement parameters, CancellationToken cancellationToken = default)
+    {
+        var response = await _backend.ExecuteAsync(name, parameters, cancellationToken).ConfigureAwait(false);
+        return ResponseSerializer.Serialize(response);
+    }
+
+    public async Task RunAsync(CancellationToken cancellationToken = default)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var message = await _transport.ReadAsync(cancellationToken).ConfigureAwait(false);
+            if (message is null)
+            {
+                break;
+            }
+
+            // The dispatcher is intentionally left as a stub for the initial scaffolding.
+        }
+    }
+}

--- a/dotnet/mcp/Server/McpServerBuilder.cs
+++ b/dotnet/mcp/Server/McpServerBuilder.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using PlaywrightMcp.Configuration;
+using PlaywrightMcp.Core.BrowserServerBackend;
+using PlaywrightMcp.Core.Context;
+using PlaywrightMcp.Core.Protocol;
+using PlaywrightMcp.Core.Services;
+using PlaywrightMcp.Core.Utils;
+using PlaywrightMcp.Tools;
+
+namespace PlaywrightMcp.Server;
+
+/// <summary>
+/// Configures and builds instances of <see cref="McpServer"/>.
+/// </summary>
+public sealed class McpServerBuilder
+{
+    private readonly ToolRegistry _toolRegistry = new();
+    private readonly ToolExecutionService _executionService = new();
+    private BrowserContextFactory _contextFactory = new();
+    private FullConfig _configuration = new();
+    private TimeProvider _timeProvider = new();
+
+    public McpServerBuilder WithConfiguration(FullConfig configuration)
+    {
+        _configuration = configuration;
+        return this;
+    }
+
+    public McpServerBuilder WithContextFactory(BrowserContextFactory factory)
+    {
+        _contextFactory = factory;
+        return this;
+    }
+
+    public McpServerBuilder WithTimeProvider(TimeProvider timeProvider)
+    {
+        _timeProvider = timeProvider;
+        return this;
+    }
+
+    public McpServerBuilder WithTools(IEnumerable<IToolDefinition> tools)
+    {
+        _toolRegistry.RegisterTools(tools);
+        return this;
+    }
+
+    public McpServerBuilder UseDefaultTools()
+    {
+        _toolRegistry.RegisterTools(BrowserTools.All);
+        return this;
+    }
+
+    public McpServer Build(IMcpTransport transport)
+    {
+        var backend = new BrowserServerBackend(_toolRegistry, _executionService, _contextFactory, _configuration, _timeProvider);
+        return new McpServer(backend, transport);
+    }
+}

--- a/dotnet/mcp/Server/StdIoTransport.cs
+++ b/dotnet/mcp/Server/StdIoTransport.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PlaywrightMcp.Server;
+
+/// <summary>
+/// Basic transport implementation using standard input/output.
+/// </summary>
+public sealed class StdIoTransport : IMcpTransport
+{
+    public Task WriteAsync(object message, CancellationToken cancellationToken)
+    {
+        var payload = JsonSerializer.Serialize(message, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        Console.Out.WriteLine(payload);
+        return Task.CompletedTask;
+    }
+
+    public Task<object?> ReadAsync(CancellationToken cancellationToken)
+    {
+        return Task.FromResult<object?>(Console.In.ReadLine());
+    }
+}

--- a/dotnet/mcp/Tools/BrowserTools.cs
+++ b/dotnet/mcp/Tools/BrowserTools.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Linq;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Tools;
+
+public static class BrowserTools
+{
+    public static IReadOnlyCollection<IToolDefinition> All { get; } = BuildTools();
+
+    private static IReadOnlyCollection<IToolDefinition> BuildTools()
+    {
+        var groups = new[]
+        {
+            CommonTools.CreateTools(),
+            ConsoleTools.CreateTools(),
+            DialogsTools.CreateTools(),
+            EvaluateTools.CreateTools(),
+            FilesTools.CreateTools(),
+            FormTools.CreateTools(),
+            InstallTools.CreateTools(),
+            KeyboardTools.CreateTools(),
+            MouseTools.CreateTools(),
+            NavigateTools.CreateTools(),
+            NetworkTools.CreateTools(),
+            PdfTools.CreateTools(),
+            ScreenshotTools.CreateTools(),
+            SnapshotTools.CreateTools(),
+            TabsTools.CreateTools(),
+            TracingTools.CreateTools(),
+            VerifyTools.CreateTools(),
+            WaitTools.CreateTools(),
+        };
+
+        return groups.SelectMany(static g => g).ToList();
+    }
+}

--- a/dotnet/mcp/Tools/CommonTools.cs
+++ b/dotnet/mcp/Tools/CommonTools.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Tools;
+
+public static class CommonTools
+{
+    public static IReadOnlyCollection<IToolDefinition> CreateTools() => new List<IToolDefinition>
+    {
+        ToolHelpers.CreatePlaceholderTool("common.echo", "Echoes the provided text back to the caller."),
+    };
+}

--- a/dotnet/mcp/Tools/ConsoleTools.cs
+++ b/dotnet/mcp/Tools/ConsoleTools.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Tools;
+
+public static class ConsoleTools
+{
+    public static IReadOnlyCollection<IToolDefinition> CreateTools() => new List<IToolDefinition>
+    {
+        ToolHelpers.CreatePlaceholderTool("console.read", "Reads messages emitted to the console."),
+    };
+}

--- a/dotnet/mcp/Tools/DialogsTools.cs
+++ b/dotnet/mcp/Tools/DialogsTools.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Tools;
+
+public static class DialogsTools
+{
+    public static IReadOnlyCollection<IToolDefinition> CreateTools() => new List<IToolDefinition>
+    {
+        ToolHelpers.CreatePlaceholderTool("dialogs.accept", "Accepts the next dialog presented by the page."),
+    };
+}

--- a/dotnet/mcp/Tools/EvaluateTools.cs
+++ b/dotnet/mcp/Tools/EvaluateTools.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Tools;
+
+public static class EvaluateTools
+{
+    public static IReadOnlyCollection<IToolDefinition> CreateTools() => new List<IToolDefinition>
+    {
+        ToolHelpers.CreatePlaceholderTool("evaluate.script", "Evaluates a script within the active page."),
+    };
+}

--- a/dotnet/mcp/Tools/FilesTools.cs
+++ b/dotnet/mcp/Tools/FilesTools.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Tools;
+
+public static class FilesTools
+{
+    public static IReadOnlyCollection<IToolDefinition> CreateTools() => new List<IToolDefinition>
+    {
+        ToolHelpers.CreatePlaceholderTool("files.save", "Saves a file produced by the browser session."),
+    };
+}

--- a/dotnet/mcp/Tools/FormTools.cs
+++ b/dotnet/mcp/Tools/FormTools.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Tools;
+
+public static class FormTools
+{
+    public static IReadOnlyCollection<IToolDefinition> CreateTools() => new List<IToolDefinition>
+    {
+        ToolHelpers.CreatePlaceholderTool("form.fill", "Fills a form field with the specified value."),
+    };
+}

--- a/dotnet/mcp/Tools/InstallTools.cs
+++ b/dotnet/mcp/Tools/InstallTools.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Tools;
+
+public static class InstallTools
+{
+    public static IReadOnlyCollection<IToolDefinition> CreateTools() => new List<IToolDefinition>
+    {
+        ToolHelpers.CreatePlaceholderTool("install.browser", "Installs the required browser binaries."),
+    };
+}

--- a/dotnet/mcp/Tools/KeyboardTools.cs
+++ b/dotnet/mcp/Tools/KeyboardTools.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Tools;
+
+public static class KeyboardTools
+{
+    public static IReadOnlyCollection<IToolDefinition> CreateTools() => new List<IToolDefinition>
+    {
+        ToolHelpers.CreatePlaceholderTool("keyboard.type", "Types text into the focused element."),
+    };
+}

--- a/dotnet/mcp/Tools/MouseTools.cs
+++ b/dotnet/mcp/Tools/MouseTools.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Tools;
+
+public static class MouseTools
+{
+    public static IReadOnlyCollection<IToolDefinition> CreateTools() => new List<IToolDefinition>
+    {
+        ToolHelpers.CreatePlaceholderTool("mouse.click", "Performs a mouse click on a target element."),
+    };
+}

--- a/dotnet/mcp/Tools/NavigateTools.cs
+++ b/dotnet/mcp/Tools/NavigateTools.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Tools;
+
+public static class NavigateTools
+{
+    public static IReadOnlyCollection<IToolDefinition> CreateTools() => new List<IToolDefinition>
+    {
+        ToolHelpers.CreatePlaceholderTool("navigate.go", "Navigates the active tab to a new URL."),
+    };
+}

--- a/dotnet/mcp/Tools/NetworkTools.cs
+++ b/dotnet/mcp/Tools/NetworkTools.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Tools;
+
+public static class NetworkTools
+{
+    public static IReadOnlyCollection<IToolDefinition> CreateTools() => new List<IToolDefinition>
+    {
+        ToolHelpers.CreatePlaceholderTool("network.inspect", "Inspects recent network requests."),
+    };
+}

--- a/dotnet/mcp/Tools/PdfTools.cs
+++ b/dotnet/mcp/Tools/PdfTools.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Tools;
+
+public static class PdfTools
+{
+    public static IReadOnlyCollection<IToolDefinition> CreateTools() => new List<IToolDefinition>
+    {
+        ToolHelpers.CreatePlaceholderTool("pdf.export", "Exports the current page as a PDF."),
+    };
+}

--- a/dotnet/mcp/Tools/ScreenshotTools.cs
+++ b/dotnet/mcp/Tools/ScreenshotTools.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Tools;
+
+public static class ScreenshotTools
+{
+    public static IReadOnlyCollection<IToolDefinition> CreateTools() => new List<IToolDefinition>
+    {
+        ToolHelpers.CreatePlaceholderTool("screenshot.capture", "Captures a screenshot of the current page."),
+    };
+}

--- a/dotnet/mcp/Tools/SnapshotTools.cs
+++ b/dotnet/mcp/Tools/SnapshotTools.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Tools;
+
+public static class SnapshotTools
+{
+    public static IReadOnlyCollection<IToolDefinition> CreateTools() => new List<IToolDefinition>
+    {
+        ToolHelpers.CreatePlaceholderTool("snapshot.generate", "Generates a textual snapshot of the page."),
+    };
+}

--- a/dotnet/mcp/Tools/TabsTools.cs
+++ b/dotnet/mcp/Tools/TabsTools.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Tools;
+
+public static class TabsTools
+{
+    public static IReadOnlyCollection<IToolDefinition> CreateTools() => new List<IToolDefinition>
+    {
+        ToolHelpers.CreatePlaceholderTool("tabs.list", "Lists the currently open tabs."),
+    };
+}

--- a/dotnet/mcp/Tools/ToolHelpers.cs
+++ b/dotnet/mcp/Tools/ToolHelpers.cs
@@ -1,0 +1,29 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using PlaywrightMcp.Core.BrowserServerBackend;
+using PlaywrightMcp.Core.Protocol;
+using PlaywrightMcp.Core.Runtime;
+
+namespace PlaywrightMcp.Tools;
+
+public static class ToolHelpers
+{
+    public static IToolDefinition CreatePlaceholderTool(string name, string description)
+        => new PlaceholderTool(name, description);
+
+    private sealed class PlaceholderTool : ToolDefinitionBase
+    {
+        public PlaceholderTool(string name, string description)
+            : base(name, description, ToolSchema.Empty)
+        {
+        }
+
+        public override Task<Response> ExecuteAsync(ToolInvocationContext context, JsonElement parameters, CancellationToken cancellationToken)
+        {
+            var response = new Response();
+            response.AddBlock(new MarkdownBlock($"Tool '{Name}' is not yet implemented."));
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/dotnet/mcp/Tools/TracingTools.cs
+++ b/dotnet/mcp/Tools/TracingTools.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Tools;
+
+public static class TracingTools
+{
+    public static IReadOnlyCollection<IToolDefinition> CreateTools() => new List<IToolDefinition>
+    {
+        ToolHelpers.CreatePlaceholderTool("tracing.start", "Starts capturing a Playwright trace."),
+    };
+}

--- a/dotnet/mcp/Tools/VerifyTools.cs
+++ b/dotnet/mcp/Tools/VerifyTools.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Tools;
+
+public static class VerifyTools
+{
+    public static IReadOnlyCollection<IToolDefinition> CreateTools() => new List<IToolDefinition>
+    {
+        ToolHelpers.CreatePlaceholderTool("verify.expect", "Asserts that a condition holds on the page."),
+    };
+}

--- a/dotnet/mcp/Tools/WaitTools.cs
+++ b/dotnet/mcp/Tools/WaitTools.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using PlaywrightMcp.Core.Protocol;
+
+namespace PlaywrightMcp.Tools;
+
+public static class WaitTools
+{
+    public static IReadOnlyCollection<IToolDefinition> CreateTools() => new List<IToolDefinition>
+    {
+        ToolHelpers.CreatePlaceholderTool("wait.for", "Waits for a condition within the page to be satisfied."),
+    };
+}


### PR DESCRIPTION
## Summary
- scaffold configuration models, capability filtering, and configuration loader for the MCP service
- implement core runtime, browser backend coordination, and server entry points following the architecture plan
- add placeholder tool groups mirroring the TypeScript structure for future implementations

## Testing
- dotnet build dotnet/mcp/PlaywrightMcpServer.csproj *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0055c0acc832985a8bc4358fcb48d