### PR TITLE
Add relaunch browser tool and delegate helper

### DIFF
--- a/dotnet/mcp/Core/Context/Context.cs
+++ b/dotnet/mcp/Core/Context/Context.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace PlaywrightMcp.Core.Context;
@@ -9,12 +10,29 @@ public sealed class Context
 {
     private readonly List<Tab> _tabs = new();
 
+    public bool IsBrowserLaunched { get; private set; }
+
     public IReadOnlyList<Tab> Tabs => _tabs;
 
     public Tab CreateTab(string id)
     {
         var tab = new Tab(id);
         _tabs.Add(tab);
+        IsBrowserLaunched = true;
+        return tab;
+    }
+
+    public void CloseBrowser()
+    {
+        _tabs.Clear();
+        IsBrowserLaunched = false;
+    }
+
+    public Tab RelaunchBrowser()
+    {
+        CloseBrowser();
+        var tab = CreateTab(Guid.NewGuid().ToString());
+        tab.RecordEvent("Browser relaunched");
         return tab;
     }
 }

--- a/dotnet/mcp/Tools/BrowserTools.cs
+++ b/dotnet/mcp/Tools/BrowserTools.cs
@@ -12,6 +12,7 @@ public static class BrowserTools
     {
         var groups = new[]
         {
+            RelaunchTools.CreateTools(),
             CommonTools.CreateTools(),
             ConsoleTools.CreateTools(),
             DialogsTools.CreateTools(),

--- a/dotnet/mcp/Tools/RelaunchTools.cs
+++ b/dotnet/mcp/Tools/RelaunchTools.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using PlaywrightMcp.Core.BrowserServerBackend;
+using PlaywrightMcp.Core.Protocol;
+using PlaywrightMcp.Core.Runtime;
+
+namespace PlaywrightMcp.Tools;
+
+/// <summary>
+/// Provides browser lifecycle management tools such as relaunch and close.
+/// </summary>
+public static class RelaunchTools
+{
+    public static IReadOnlyCollection<IToolDefinition> CreateTools() => new List<IToolDefinition>
+    {
+        ToolHelpers.CreateDelegateTool(
+            name: "browser_relaunch",
+            description: "(Re)launch browser and open a fresh page.",
+            handler: RelaunchAsync),
+        ToolHelpers.CreateDelegateTool(
+            name: "browser_close",
+            description: "Close and dispose Playwright browser resources.",
+            handler: CloseAsync)
+    };
+
+    private static Task<Response> RelaunchAsync(
+        ToolInvocationContext context,
+        JsonElement parameters,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var tab = context.BrowserContext.RelaunchBrowser();
+
+        var response = new Response();
+        response.AddBlock(new MarkdownBlock("Browser relaunched and ready for automation."));
+        response.Metadata["relaunched"] = true;
+        response.Metadata["activeTabId"] = tab.Id;
+        response.Metadata["tabs"] = context.BrowserContext.Tabs.Select(t => t.Id).ToArray();
+        response.Metadata["isBrowserLaunched"] = context.BrowserContext.IsBrowserLaunched;
+
+        return Task.FromResult(response);
+    }
+
+    private static Task<Response> CloseAsync(
+        ToolInvocationContext context,
+        JsonElement parameters,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        context.BrowserContext.CloseBrowser();
+
+        var response = new Response();
+        response.AddBlock(new MarkdownBlock("Browser session closed."));
+        response.Metadata["closed"] = true;
+        response.Metadata["isBrowserLaunched"] = context.BrowserContext.IsBrowserLaunched;
+        response.Metadata["tabs"] = context.BrowserContext.Tabs.Select(t => t.Id).ToArray();
+
+        return Task.FromResult(response);
+    }
+}

--- a/dotnet/mcp/Tools/ToolHelpers.cs
+++ b/dotnet/mcp/Tools/ToolHelpers.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,20 +11,39 @@ namespace PlaywrightMcp.Tools;
 public static class ToolHelpers
 {
     public static IToolDefinition CreatePlaceholderTool(string name, string description)
-        => new PlaceholderTool(name, description);
-
-    private sealed class PlaceholderTool : ToolDefinitionBase
-    {
-        public PlaceholderTool(string name, string description)
-            : base(name, description, ToolSchema.Empty)
+        => CreateDelegateTool(name, description, (context, parameters, cancellationToken) =>
         {
+            var response = new Response();
+            response.AddBlock(new MarkdownBlock($"Tool '{name}' is not yet implemented."));
+            return Task.FromResult(response);
+        });
+
+    public static IToolDefinition CreateDelegateTool(
+        string name,
+        string description,
+        Func<ToolInvocationContext, JsonElement, CancellationToken, Task<Response>> handler,
+        ToolSchema? schema = null)
+        => new DelegateToolDefinition(
+            name,
+            description,
+            schema ?? ToolSchema.Empty,
+            handler ?? throw new ArgumentNullException(nameof(handler)));
+
+    private sealed class DelegateToolDefinition : ToolDefinitionBase
+    {
+        private readonly Func<ToolInvocationContext, JsonElement, CancellationToken, Task<Response>> _handler;
+
+        public DelegateToolDefinition(
+            string name,
+            string description,
+            ToolSchema schema,
+            Func<ToolInvocationContext, JsonElement, CancellationToken, Task<Response>> handler)
+            : base(name, description, schema)
+        {
+            _handler = handler;
         }
 
         public override Task<Response> ExecuteAsync(ToolInvocationContext context, JsonElement parameters, CancellationToken cancellationToken)
-        {
-            var response = new Response();
-            response.AddBlock(new MarkdownBlock($"Tool '{Name}' is not yet implemented."));
-            return Task.FromResult(response);
-        }
+            => _handler(context, parameters, cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary
- add relaunch and close tools that expose browser lifecycle metadata
- expose browser lifecycle helpers on the shared context and register the new tool group
- introduce a delegate-based helper so tools execute real MCP callbacks instead of placeholders

## Testing
- dotnet build dotnet/mcp/PlaywrightMcpServer.csproj *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e079dc99ac8329ab87dffa0d3752d1