### PR TITLE
Add MCP Playwright tool implementations for .NET server

### DIFF
--- a/dotnet/PlaywrightTools.Actions.Common.cs
+++ b/dotnet/PlaywrightTools.Actions.Common.cs
@@ -1,0 +1,186 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "common.echo")]
+    [Description("Echoes the provided text back to the caller.")]
+    public static Task<string> EchoAsync(
+        [Description("Text to echo back to the caller.")] string text,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        text ??= string.Empty;
+        return Task.FromResult(Serialize(new
+        {
+            echoed = text,
+            length = text.Length
+        }));
+    }
+
+    [McpServerTool(Name = "console.read")]
+    [Description("Reads messages emitted to the console.")]
+    public static Task<string> ConsoleReadAsync(
+        [Description("Optional console message type filter (log, warning, error, etc.).")] string? type = null,
+        [Description("Maximum number of recent messages to return. Use null for all available messages.")] int? limit = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var snapshot = SnapshotConsoleMessages();
+        var filtered = string.IsNullOrWhiteSpace(type)
+            ? snapshot
+            : snapshot.Where(entry => string.Equals(entry.Type, type, StringComparison.OrdinalIgnoreCase)).ToArray();
+
+        if (limit is > 0 && filtered.Length > limit.Value)
+        {
+            filtered = filtered[^limit.Value..];
+        }
+
+        return Task.FromResult(Serialize(new
+        {
+            count = filtered.Length,
+            messages = filtered
+        }));
+    }
+
+    [McpServerTool(Name = "network.inspect")]
+    [Description("Inspects recent network requests.")]
+    public static Task<string> NetworkInspectAsync(
+        [Description("Maximum number of recent requests to return. Use null for all tracked requests.")] int? limit = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var snapshot = SnapshotNetworkRequests();
+        if (limit is > 0 && snapshot.Length > limit.Value)
+        {
+            snapshot = snapshot[^limit.Value..];
+        }
+
+        return Task.FromResult(Serialize(new
+        {
+            count = snapshot.Length,
+            requests = snapshot
+        }));
+    }
+
+    [McpServerTool(Name = "tabs.list")]
+    [Description("Lists the currently open tabs.")]
+    public static async Task<string> TabsListAsync(
+        [Description("Whether to include the HTML title for each tab (may require additional Playwright calls).")] bool includeTitles = true,
+        CancellationToken cancellationToken = default)
+    {
+        var context = await GetContextAsync(cancellationToken).ConfigureAwait(false);
+        var pages = context.Pages;
+
+        var tabTasks = pages.Select(async (page, index) => new
+        {
+            index,
+            url = page.Url,
+            isActive = page == _page,
+            title = includeTitles ? await page.TitleAsync().ConfigureAwait(false) : null,
+            isClosed = page.IsClosed
+        });
+
+        var tabs = await Task.WhenAll(tabTasks).ConfigureAwait(false);
+
+        return Serialize(new
+        {
+            activeIndex = GetPageIndex(_page ?? pages.FirstOrDefault() ?? throw new InvalidOperationException("No active page.")),
+            tabs
+        });
+    }
+
+    [McpServerTool(Name = "verify.expect")]
+    [Description("Asserts that a condition holds on the page.")]
+    public static async Task<string> VerifyExpectAsync(
+        [Description("Selector identifying the element to verify.")] string selector,
+        [Description("Text that should be contained within the element.")] string expectedSubstring,
+        [Description("Timeout in milliseconds to wait for the element to appear before verification.")] int? timeoutMs = null,
+        CancellationToken cancellationToken = default)
+    {
+        var locator = await GetLocatorAsync(selector, timeoutMs, cancellationToken).ConfigureAwait(false);
+        var text = await locator.InnerTextAsync().ConfigureAwait(false) ?? string.Empty;
+        var passed = text.IndexOf(expectedSubstring, StringComparison.OrdinalIgnoreCase) >= 0;
+
+        return Serialize(new
+        {
+            passed,
+            selector,
+            expected = expectedSubstring,
+            actual = text
+        });
+    }
+
+    [McpServerTool(Name = "wait.for")]
+    [Description("Waits for a condition within the page to be satisfied.")]
+    public static async Task<string> WaitForAsync(
+        [Description("Selector to wait for before continuing.")] string selector,
+        [Description("Timeout in milliseconds to wait before giving up.")] int timeoutMs = 30000,
+        [Description("Which state the selector should reach before resolving (attached, detached, visible, hidden).")] string state = "visible",
+        CancellationToken cancellationToken = default)
+    {
+        var page = await GetPageAsync(cancellationToken).ConfigureAwait(false);
+
+        var waitState = state?.ToLowerInvariant() switch
+        {
+            "attached" => WaitForSelectorState.Attached,
+            "detached" => WaitForSelectorState.Detached,
+            "hidden" => WaitForSelectorState.Hidden,
+            _ => WaitForSelectorState.Visible
+        };
+
+        await page.WaitForSelectorAsync(selector, new PageWaitForSelectorOptions
+        {
+            Timeout = timeoutMs,
+            State = waitState
+        }).ConfigureAwait(false);
+
+        return Serialize(new
+        {
+            waitedFor = selector,
+            timeoutMs,
+            state = waitState.ToString()
+        });
+    }
+
+    [McpServerTool(Name = "snapshot.generate")]
+    [Description("Generates a textual snapshot of the page.")]
+    public static async Task<string> SnapshotGenerateAsync(
+        [Description("Whether to include the full HTML content.")] bool includeHtml = true,
+        [Description("Optional selector to extract text content from.")] string? selector = null,
+        CancellationToken cancellationToken = default)
+    {
+        var page = await GetPageAsync(cancellationToken).ConfigureAwait(false);
+
+        string? content = null;
+        if (!string.IsNullOrWhiteSpace(selector))
+        {
+            var locator = await GetLocatorAsync(selector, null, cancellationToken).ConfigureAwait(false);
+            content = await locator.InnerTextAsync().ConfigureAwait(false);
+        }
+        else if (includeHtml)
+        {
+            content = await page.ContentAsync().ConfigureAwait(false);
+        }
+        else
+        {
+            content = await page.InnerTextAsync("body").ConfigureAwait(false);
+        }
+
+        return Serialize(new
+        {
+            url = page.Url,
+            timestamp = DateTimeOffset.UtcNow,
+            content
+        });
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.Dialogs.cs
+++ b/dotnet/PlaywrightTools.Actions.Dialogs.cs
@@ -1,0 +1,97 @@
+using System;
+using System.ComponentModel;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "dialogs.accept")]
+    [Description("Accepts the next dialog presented by the page.")]
+    public static async Task<string> DialogsAcceptAsync(
+        [Description("Optional text to provide when accepting prompt dialogs.")] string? promptText = null,
+        CancellationToken cancellationToken = default)
+    {
+        var page = await GetPageAsync(cancellationToken).ConfigureAwait(false);
+        var completion = new TaskCompletionSource<(string Type, string Message, string? Default)>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        async void Handler(object? sender, IDialog dialog)
+        {
+            page.Dialog -= Handler;
+            try
+            {
+                if (dialog.Type == DialogType.Prompt && promptText is not null)
+                {
+                    await dialog.AcceptAsync(promptText).ConfigureAwait(false);
+                }
+                else
+                {
+                    await dialog.AcceptAsync().ConfigureAwait(false);
+                }
+
+                completion.TrySetResult((dialog.Type, dialog.Message, dialog.DefaultValue));
+            }
+            catch (Exception ex)
+            {
+                completion.TrySetException(ex);
+            }
+        }
+
+        page.Dialog += Handler;
+        using var registration = cancellationToken.Register(() =>
+        {
+            page.Dialog -= Handler;
+            completion.TrySetCanceled(cancellationToken);
+        });
+
+        var result = await completion.Task.ConfigureAwait(false);
+
+        return Serialize(new
+        {
+            accepted = true,
+            type = result.Type,
+            message = result.Message,
+            defaultValue = result.Default,
+            promptText
+        });
+    }
+
+    [McpServerTool(Name = "evaluate.script")]
+    [Description("Evaluates a script within the active page.")]
+    public static async Task<string> EvaluateScriptAsync(
+        [Description("JavaScript expression or function to evaluate.")] string script,
+        [Description("Optional JSON encoded argument passed to the script as the first parameter.")] string? jsonArgument = null,
+        CancellationToken cancellationToken = default)
+    {
+        var page = await GetPageAsync(cancellationToken).ConfigureAwait(false);
+        object? argument = null;
+
+        if (!string.IsNullOrWhiteSpace(jsonArgument))
+        {
+            try
+            {
+                argument = JsonSerializer.Deserialize<object?>(jsonArgument);
+            }
+            catch (JsonException ex)
+            {
+                return Serialize(new
+                {
+                    evaluated = false,
+                    error = ex.Message
+                });
+            }
+        }
+
+        var result = await page.EvaluateAsync<object?>(script, argument).ConfigureAwait(false);
+
+        return Serialize(new
+        {
+            evaluated = true,
+            result
+        });
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.Input.cs
+++ b/dotnet/PlaywrightTools.Actions.Input.cs
@@ -1,0 +1,128 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "form.fill")]
+    [Description("Fills a form field with the specified value.")]
+    public static async Task<string> FormFillAsync(
+        [Description("Playwright selector identifying the target element.")] string selector,
+        [Description("Value to fill into the field.")] string value,
+        [Description("Timeout in milliseconds for locating the element.")] int? timeoutMs = null,
+        CancellationToken cancellationToken = default)
+    {
+        var locator = await GetLocatorAsync(selector, timeoutMs, cancellationToken).ConfigureAwait(false);
+        await locator.FillAsync(value ?? string.Empty, new LocatorFillOptions
+        {
+            Timeout = timeoutMs
+        }).ConfigureAwait(false);
+
+        return Serialize(new
+        {
+            filled = true,
+            selector,
+            value
+        });
+    }
+
+    [McpServerTool(Name = "keyboard.type")]
+    [Description("Types text into the focused element.")]
+    public static async Task<string> KeyboardTypeAsync(
+        [Description("Text to type into the active element.")] string text,
+        [Description("Delay between individual key presses in milliseconds.")] int? delayMs = null,
+        CancellationToken cancellationToken = default)
+    {
+        var page = await GetPageAsync(cancellationToken).ConfigureAwait(false);
+        await page.Keyboard.TypeAsync(text ?? string.Empty, new KeyboardTypeOptions
+        {
+            Delay = delayMs
+        }).ConfigureAwait(false);
+
+        return Serialize(new
+        {
+            typed = text ?? string.Empty,
+            delayMs
+        });
+    }
+
+    [McpServerTool(Name = "mouse.click")]
+    [Description("Performs a mouse click on a target element.")]
+    public static async Task<string> MouseClickAsync(
+        [Description("Playwright selector identifying the element to click.")] string selector,
+        [Description("Mouse button to use (left, middle, right).")] string? button = null,
+        [Description("Number of consecutive clicks to perform.")] int? clickCount = null,
+        [Description("Delay between mouse down and mouse up in milliseconds.")] int? delayMs = null,
+        [Description("Timeout in milliseconds for locating the element.")] int? timeoutMs = null,
+        [Description("Optional keyboard modifiers (Alt, Control, Meta, Shift, ControlOrMeta).")] string[]? modifiers = null,
+        CancellationToken cancellationToken = default)
+    {
+        var locator = await GetLocatorAsync(selector, timeoutMs, cancellationToken).ConfigureAwait(false);
+        var parsedButton = ParseMouseButton(button);
+        var parsedModifiers = ParseModifiers(modifiers)?.ToArray();
+
+        await locator.ClickAsync(new LocatorClickOptions
+        {
+            Button = parsedButton,
+            ClickCount = clickCount,
+            Delay = delayMs,
+            Timeout = timeoutMs,
+            Modifiers = parsedModifiers
+        }).ConfigureAwait(false);
+
+        return Serialize(new
+        {
+            clicked = true,
+            selector,
+            button = parsedButton?.ToString() ?? "Left",
+            clickCount = clickCount ?? 1,
+            delayMs
+        });
+    }
+
+    [McpServerTool(Name = "files.save")]
+    [Description("Saves a file produced by the browser session.")]
+    public static async Task<string> FilesSaveAsync(
+        [Description("Base64 encoded file contents.")] string base64Content,
+        [Description("Desired file name relative to the downloads directory.")] string fileName,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        EnsureDirectories();
+
+        byte[] bytes;
+        try
+        {
+            bytes = Convert.FromBase64String(base64Content ?? string.Empty);
+        }
+        catch (FormatException ex)
+        {
+            return Serialize(new
+            {
+                saved = false,
+                error = ex.Message
+            });
+        }
+
+        var name = string.IsNullOrWhiteSpace(fileName)
+            ? $"download-{DateTimeOffset.UtcNow:yyyyMMddHHmmssfff}.bin"
+            : fileName;
+
+        var path = ResolveOutputPath(name, DownloadsDir);
+        await File.WriteAllBytesAsync(path, bytes, cancellationToken).ConfigureAwait(false);
+
+        return Serialize(new
+        {
+            saved = true,
+            path,
+            size = bytes.Length
+        });
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.Install.cs
+++ b/dotnet/PlaywrightTools.Actions.Install.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "install.browser")]
+    [Description("Installs the required browser binaries.")]
+    public static Task<string> InstallBrowserAsync(
+        [Description("Name of the browser channel to install (e.g., chromium, firefox, webkit, msedge).")] string browser,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var message = $"Automatic installation for '{browser}' is not yet implemented in the .NET server.";
+        return Task.FromResult(Serialize(new
+        {
+            installed = false,
+            browser,
+            message
+        }));
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.Navigation.cs
+++ b/dotnet/PlaywrightTools.Actions.Navigation.cs
@@ -1,0 +1,156 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "navigate.go")]
+    [Description("Navigates the active tab to a new URL.")]
+    public static async Task<string> NavigateGoAsync(
+        [Description("The URL to navigate to.")] string url,
+        [Description("Navigation timeout in milliseconds. Use null to apply Playwright defaults.")] int? timeoutMs = null,
+        CancellationToken cancellationToken = default)
+    {
+        var page = await GetPageAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var parsed))
+        {
+            return Serialize(new
+            {
+                navigated = false,
+                url,
+                error = "Invalid URL format."
+            });
+        }
+
+        var response = await page.GotoAsync(parsed.ToString(), new PageGotoOptions
+        {
+            Timeout = timeoutMs,
+            WaitUntil = WaitUntilState.NetworkIdle
+        }).ConfigureAwait(false);
+
+        var title = await page.TitleAsync().ConfigureAwait(false);
+
+        return Serialize(new
+        {
+            navigated = true,
+            url = page.Url,
+            status = response?.Status,
+            title
+        });
+    }
+
+    [McpServerTool(Name = "screenshot.capture")]
+    [Description("Captures a screenshot of the current page.")]
+    public static async Task<string> ScreenshotCaptureAsync(
+        [Description("Optional output file name. When omitted a timestamped name will be generated.")] string? fileName = null,
+        [Description("Capture the entire scrollable page instead of the viewport.")] bool fullPage = false,
+        CancellationToken cancellationToken = default)
+    {
+        var page = await GetPageAsync(cancellationToken).ConfigureAwait(false);
+        EnsureDirectories();
+
+        var name = string.IsNullOrWhiteSpace(fileName)
+            ? $"screenshot-{DateTimeOffset.UtcNow:yyyyMMddHHmmssfff}.png"
+            : fileName.EndsWith(".png", StringComparison.OrdinalIgnoreCase) ? fileName : fileName + ".png";
+
+        var path = ResolveOutputPath(name, ShotsDir);
+
+        await page.ScreenshotAsync(new PageScreenshotOptions
+        {
+            Path = path,
+            FullPage = fullPage
+        }).ConfigureAwait(false);
+
+        return Serialize(new
+        {
+            captured = true,
+            path,
+            fullPage
+        });
+    }
+
+    [McpServerTool(Name = "pdf.export")]
+    [Description("Exports the current page as a PDF.")]
+    public static async Task<string> PdfExportAsync(
+        [Description("Optional output file name. When omitted a timestamped name will be generated.")] string? fileName = null,
+        [Description("Paper format such as A4, Letter, Legal, etc.")] string format = "A4",
+        CancellationToken cancellationToken = default)
+    {
+        if (!_isChromium)
+        {
+            return Serialize(new
+            {
+                exported = false,
+                error = "PDF export is only supported when using a Chromium-based browser."
+            });
+        }
+
+        var page = await GetPageAsync(cancellationToken).ConfigureAwait(false);
+        EnsureDirectories();
+
+        var name = string.IsNullOrWhiteSpace(fileName)
+            ? $"page-{DateTimeOffset.UtcNow:yyyyMMddHHmmssfff}.pdf"
+            : fileName.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase) ? fileName : fileName + ".pdf";
+
+        var path = ResolveOutputPath(name, PdfDir);
+
+        await page.PdfAsync(new PagePdfOptions
+        {
+            Path = path,
+            Format = format
+        }).ConfigureAwait(false);
+
+        return Serialize(new
+        {
+            exported = true,
+            path,
+            format
+        });
+    }
+
+    [McpServerTool(Name = "tracing.start")]
+    [Description("Starts capturing a Playwright trace.")]
+    public static async Task<string> TracingStartAsync(
+        [Description("Optional human readable title for the trace session.")] string? title = null,
+        [Description("Include JavaScript source files in the trace.")] bool includeSources = true,
+        [Description("Capture screenshots during tracing.")] bool includeScreenshots = true,
+        [Description("Capture DOM snapshots during tracing.")] bool includeSnapshots = true,
+        CancellationToken cancellationToken = default)
+    {
+        if (_tracingActive)
+        {
+            return Serialize(new
+            {
+                tracing = "already_active"
+            });
+        }
+
+        var context = await GetContextAsync(cancellationToken).ConfigureAwait(false);
+
+        await context.Tracing.StartAsync(new TracingStartOptions
+        {
+            Title = title,
+            Sources = includeSources,
+            Screenshots = includeScreenshots,
+            Snapshots = includeSnapshots
+        }).ConfigureAwait(false);
+
+        _tracingActive = true;
+
+        return Serialize(new
+        {
+            tracing = "started",
+            title,
+            includeSources,
+            includeScreenshots,
+            includeSnapshots
+        });
+    }
+}

--- a/dotnet/PlaywrightTools.cs
+++ b/dotnet/PlaywrightTools.cs
@@ -44,6 +44,9 @@ public sealed partial class PlaywrightTools
     private static string ShotsDir =>
         Path.GetFullPath("./shots");
 
+    private static string PdfDir =>
+        Path.GetFullPath("./pdf");
+
     private static string TracesDir =>
         Path.GetFullPath("./traces");
 
@@ -252,6 +255,7 @@ public sealed partial class PlaywrightTools
             Directory.CreateDirectory(DownloadsDir);
             Directory.CreateDirectory(VideosDir);
             Directory.CreateDirectory(ShotsDir);
+            Directory.CreateDirectory(PdfDir);
             Directory.CreateDirectory(TracesDir);
         }
     }
@@ -298,7 +302,7 @@ public sealed partial class PlaywrightTools
     }
 
     // ----------------------
-    // Helper methods (±¾ÎÄ¼şÄÚÌá¹©£¬½â¾ö¡°µ±Ç°ÉÏÏÂÎÄÖĞ²»´æÔÚÃû³Æ ...¡±)
+    // Helper methods (æœ¬æ–‡ä»¶å†…æä¾›ï¼Œè§£å†³â€œå½“å‰ä¸Šä¸‹æ–‡ä¸­ä¸å­˜åœ¨åç§° ...â€)
     // ----------------------
 
     private static MouseButton? ParseMouseButton(string? button)
@@ -309,7 +313,7 @@ public sealed partial class PlaywrightTools
             case "left": return MouseButton.Left;
             case "middle": return MouseButton.Middle;
             case "right": return MouseButton.Right;
-            default: return null; // Î´Ê¶±ğÔò½»¸ø Playwright Ä¬ÈÏ£¨Left£©
+            default: return null; // æœªè¯†åˆ«åˆ™äº¤ç»™ Playwright é»˜è®¤ï¼ˆLeftï¼‰
         }
     }
 
@@ -340,11 +344,11 @@ public sealed partial class PlaywrightTools
                         : KeyboardModifier.Control);
                     break;
                 default:
-                    // ºöÂÔÎ´ÖªĞŞÊÎ¼ü£¬±£³Ö¿íÈİ
+                    // å¿½ç•¥æœªçŸ¥ä¿®é¥°é”®ï¼Œä¿æŒå®½å®¹
                     break;
             }
         }
-        // È¥ÖØ
+        // å»é‡
         return list.Distinct().ToArray();
     }
 


### PR DESCRIPTION
## Summary
- implement Playwright MCP tools as partial class methods with McpServerTool metadata for navigation, input, console, and other capabilities
- extend PlaywrightTools helpers to provision a PDF output directory for generated files

## Testing
- not run (dotnet CLI unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e08006eee48329a5d76c225d36f931