### PR TITLE
Add stub MCP tool definitions for Playwright browser actions

### DIFF
--- a/dotnet/PlaywrightTools.Actions.common.cs
+++ b/dotnet/PlaywrightTools.Actions.common.cs
@@ -1,0 +1,40 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "browser_close")]
+    [Description("Close the page.")]
+    public static async Task<string> BrowserCloseAsync(
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for closing the current browser page.
+        // Pseudocode:
+        // 1. Retrieve the active page instance.
+        // 2. Invoke the page close operation.
+        // 3. Return a serialized result confirming the page has closed.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+
+    [McpServerTool(Name = "browser_resize")]
+    [Description("Resize the browser window.")]
+    public static async Task<string> BrowserResizeAsync(
+        [Description("Width of the browser window.")] int width,
+        [Description("Height of the browser window.")] int height,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for resizing the browser window.
+        // Pseudocode:
+        // 1. Retrieve the active browser context or page.
+        // 2. Apply the new viewport dimensions using the provided width and height.
+        // 3. Return a serialized result describing the updated size.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.console.cs
+++ b/dotnet/PlaywrightTools.Actions.console.cs
@@ -1,0 +1,25 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "browser_console_messages")]
+    [Description("Returns all console messages.")]
+    public static async Task<string> BrowserConsoleMessagesAsync(
+        [Description("Only return error messages.")] bool? onlyErrors = null,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for retrieving console messages from the page.
+        // Pseudocode:
+        // 1. Gather console entries emitted by the page since load.
+        // 2. Filter messages when onlyErrors is requested.
+        // 3. Return the collected console output in serialized form.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.dialogs.cs
+++ b/dotnet/PlaywrightTools.Actions.dialogs.cs
@@ -1,0 +1,26 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "browser_handle_dialog")]
+    [Description("Handle a dialog.")]
+    public static async Task<string> BrowserHandleDialogAsync(
+        [Description("Whether to accept the dialog.")] bool accept,
+        [Description("The text of the prompt in case of a prompt dialog.")] string? promptText = null,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for handling dialogs presented by the page.
+        // Pseudocode:
+        // 1. Await the appearance of a dialog event on the active page.
+        // 2. Apply the accept or dismiss action, optionally supplying prompt text.
+        // 3. Return a serialized result describing the dialog interaction.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.evaluate.cs
+++ b/dotnet/PlaywrightTools.Actions.evaluate.cs
@@ -1,0 +1,27 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "browser_evaluate")]
+    [Description("Evaluate JavaScript expression on page or element.")]
+    public static async Task<string> BrowserEvaluateAsync(
+        [Description("JavaScript function to execute, optionally receiving the element when provided.")] string function,
+        [Description("Human-readable element description used to obtain permission to interact with the element.")] string? element = null,
+        [Description("Exact target element reference from the page snapshot.")] string? elementRef = null,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for evaluating JavaScript within the browser context.
+        // Pseudocode:
+        // 1. Determine the target (page or element) based on provided descriptors.
+        // 2. Execute the supplied JavaScript function against the target.
+        // 3. Capture and serialize the evaluation result for return.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.files.cs
+++ b/dotnet/PlaywrightTools.Actions.files.cs
@@ -1,0 +1,25 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "browser_file_upload")]
+    [Description("Upload one or multiple files.")]
+    public static async Task<string> BrowserFileUploadAsync(
+        [Description("The absolute paths to the files to upload. Can be single file or multiple files. If omitted, file chooser is cancelled.")] string[]? paths = null,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for uploading files to the active page.
+        // Pseudocode:
+        // 1. Resolve and validate the provided file paths.
+        // 2. Interact with the browser's file chooser to provide the files.
+        // 3. Return a serialized result summarizing the upload action.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.form.cs
+++ b/dotnet/PlaywrightTools.Actions.form.cs
@@ -1,0 +1,26 @@
+using System;
+using System.ComponentModel;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "browser_fill_form")]
+    [Description("Fill multiple form fields.")]
+    public static async Task<string> BrowserFillFormAsync(
+        [Description("Fields to fill in (name, type, ref, value).")] JsonElement fields,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for populating multiple form fields.
+        // Pseudocode:
+        // 1. Iterate over each field descriptor in the provided payload.
+        // 2. Locate the corresponding element and apply the value based on its type.
+        // 3. Return a serialized summary of the filled fields and outcomes.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.install.cs
+++ b/dotnet/PlaywrightTools.Actions.install.cs
@@ -1,0 +1,24 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "browser_install")]
+    [Description("Install the browser specified in the config.")]
+    public static async Task<string> BrowserInstallAsync(
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for installing the configured browser.
+        // Pseudocode:
+        // 1. Determine the browser package to install from configuration.
+        // 2. Execute the installation routine and monitor progress.
+        // 3. Return serialized results summarizing installation success or failure.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.keyboard.cs
+++ b/dotnet/PlaywrightTools.Actions.keyboard.cs
@@ -1,0 +1,44 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "browser_press_key")]
+    [Description("Press a key on the keyboard.")]
+    public static async Task<string> BrowserPressKeyAsync(
+        [Description("Name of the key to press or a character to generate, such as `ArrowLeft` or `a`.")] string key,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for simulating a keyboard key press.
+        // Pseudocode:
+        // 1. Retrieve the active page instance.
+        // 2. Issue the key press event using the specified key identifier.
+        // 3. Return a serialized result detailing the key action performed.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+
+    [McpServerTool(Name = "browser_type")]
+    [Description("Type text into editable element.")]
+    public static async Task<string> BrowserTypeAsync(
+        [Description("Human-readable element description used to obtain permission to interact with the element.")] string element,
+        [Description("Exact target element reference from the page snapshot.")] string elementRef,
+        [Description("Text to type into the element.")] string text,
+        [Description("Whether to submit entered text (press Enter after).")] bool? submit = null,
+        [Description("Whether to type one character at a time. Useful for triggering key handlers in the page. By default entire text is filled in at once.")] bool? slowly = null,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for typing text into a specified element.
+        // Pseudocode:
+        // 1. Locate the element using the provided descriptors.
+        // 2. Type the supplied text, honoring the submit and slowly flags as needed.
+        // 3. Return a serialized summary of the typing interaction.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.mouse.cs
+++ b/dotnet/PlaywrightTools.Actions.mouse.cs
@@ -1,0 +1,63 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "browser_mouse_move_xy")]
+    [Description("Move mouse to a given position.")]
+    public static async Task<string> BrowserMouseMoveXyAsync(
+        [Description("Human-readable element description used to obtain permission to interact with the element.")] string element,
+        [Description("X coordinate.")] double x,
+        [Description("Y coordinate.")] double y,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for moving the mouse pointer to coordinates.
+        // Pseudocode:
+        // 1. Resolve the coordinate system relative to the specified element or viewport.
+        // 2. Move the mouse to the target coordinates.
+        // 3. Return a serialized response confirming the final pointer position.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+
+    [McpServerTool(Name = "browser_mouse_click_xy")]
+    [Description("Click left mouse button at a given position.")]
+    public static async Task<string> BrowserMouseClickXyAsync(
+        [Description("Human-readable element description used to obtain permission to interact with the element.")] string element,
+        [Description("X coordinate.")] double x,
+        [Description("Y coordinate.")] double y,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for clicking at the specified coordinates.
+        // Pseudocode:
+        // 1. Move the pointer to the designated coordinates.
+        // 2. Perform the click action at that position.
+        // 3. Return serialized details of the click event.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+
+    [McpServerTool(Name = "browser_mouse_drag_xy")]
+    [Description("Drag left mouse button to a given position.")]
+    public static async Task<string> BrowserMouseDragXyAsync(
+        [Description("Human-readable element description used to obtain permission to interact with the element.")] string element,
+        [Description("Start X coordinate.")] double startX,
+        [Description("Start Y coordinate.")] double startY,
+        [Description("End X coordinate.")] double endX,
+        [Description("End Y coordinate.")] double endY,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for dragging between coordinate points.
+        // Pseudocode:
+        // 1. Move the pointer to the starting coordinates and press the mouse button.
+        // 2. Drag to the ending coordinates while holding the button.
+        // 3. Release the button and return serialized drag information.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.navigate.cs
+++ b/dotnet/PlaywrightTools.Actions.navigate.cs
@@ -1,0 +1,40 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "browser_navigate")]
+    [Description("Navigate to a URL.")]
+    public static async Task<string> BrowserNavigateAsync(
+        [Description("The URL to navigate to.")] string url,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for navigating to the requested URL.
+        // Pseudocode:
+        // 1. Validate and normalize the provided URL.
+        // 2. Retrieve the active page instance.
+        // 3. Direct the page to navigate to the URL and await completion.
+        // 4. Return navigation details in a serialized payload.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+
+    [McpServerTool(Name = "browser_navigate_back")]
+    [Description("Go back to the previous page.")]
+    public static async Task<string> BrowserNavigateBackAsync(
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for returning to the previous page in history.
+        // Pseudocode:
+        // 1. Retrieve the active page instance.
+        // 2. Trigger the go-back navigation if available.
+        // 3. Return the updated history state in a serialized payload.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.network.cs
+++ b/dotnet/PlaywrightTools.Actions.network.cs
@@ -1,0 +1,24 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "browser_network_requests")]
+    [Description("Returns all network requests since loading the page.")]
+    public static async Task<string> BrowserNetworkRequestsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for collecting network requests from the session.
+        // Pseudocode:
+        // 1. Access stored or live network request data from the page or context.
+        // 2. Aggregate the requests since page load.
+        // 3. Return the data in a serialized structure.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.pdf.cs
+++ b/dotnet/PlaywrightTools.Actions.pdf.cs
@@ -1,0 +1,25 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "browser_pdf_save")]
+    [Description("Save page as PDF.")]
+    public static async Task<string> BrowserPdfSaveAsync(
+        [Description("File name to save the pdf to. Defaults to `page-{timestamp}.pdf` if not specified.")] string? filename = null,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for exporting the current page as a PDF document.
+        // Pseudocode:
+        // 1. Configure PDF export options, including the optional filename.
+        // 2. Generate the PDF from the active page context.
+        // 3. Return serialized information about the saved PDF file.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.screenshot.cs
+++ b/dotnet/PlaywrightTools.Actions.screenshot.cs
@@ -1,0 +1,29 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "browser_take_screenshot")]
+    [Description("Take a screenshot of the current page.")]
+    public static async Task<string> BrowserTakeScreenshotAsync(
+        [Description("Image format for the screenshot. Default is png.")] string? type = null,
+        [Description("File name to save the screenshot to. Defaults to an auto-generated name if not specified.")] string? filename = null,
+        [Description("Human-readable element description used to obtain permission to interact with the element.")] string? element = null,
+        [Description("Exact target element reference from the page snapshot.")] string? elementRef = null,
+        [Description("When true, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Cannot be used with element screenshots.")] bool? fullPage = null,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for capturing screenshots.
+        // Pseudocode:
+        // 1. Determine whether to capture the full page or a specific element.
+        // 2. Configure screenshot options based on the provided arguments.
+        // 3. Capture and persist the screenshot, returning serialized metadata.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.snapshot.cs
+++ b/dotnet/PlaywrightTools.Actions.snapshot.cs
@@ -1,0 +1,94 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "browser_click")]
+    [Description("Perform click on a web page.")]
+    public static async Task<string> BrowserClickAsync(
+        [Description("Human-readable element description used to obtain permission to interact with the element.")] string element,
+        [Description("Exact target element reference from the page snapshot.")] string elementRef,
+        [Description("Whether to perform a double click instead of a single click.")] bool? doubleClick = null,
+        [Description("Button to click, defaults to left.")] string? button = null,
+        [Description("Modifier keys to press.")] string[]? modifiers = null,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for clicking on the specified element.
+        // Pseudocode:
+        // 1. Locate the element from the snapshot reference.
+        // 2. Execute the click with the desired button, click count, and modifiers.
+        // 3. Return a serialized result summarizing the click action.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+
+    [McpServerTool(Name = "browser_drag")]
+    [Description("Perform drag and drop between two elements.")]
+    public static async Task<string> BrowserDragAsync(
+        [Description("Human-readable source element description used to obtain the permission to interact with the element.")] string startElement,
+        [Description("Exact source element reference from the page snapshot.")] string startRef,
+        [Description("Human-readable target element description used to obtain the permission to interact with the element.")] string endElement,
+        [Description("Exact target element reference from the page snapshot.")] string endRef,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for dragging from one element to another.
+        // Pseudocode:
+        // 1. Resolve both source and target elements using the provided descriptors.
+        // 2. Perform the drag-and-drop interaction via the page.
+        // 3. Return a serialized summary describing the drag operation.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+
+    [McpServerTool(Name = "browser_hover")]
+    [Description("Hover over element on page.")]
+    public static async Task<string> BrowserHoverAsync(
+        [Description("Human-readable element description used to obtain permission to interact with the element.")] string element,
+        [Description("Exact target element reference from the page snapshot.")] string elementRef,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for hovering the pointer over the specified element.
+        // Pseudocode:
+        // 1. Locate the element using the snapshot reference.
+        // 2. Move the pointer to hover over the element.
+        // 3. Return a serialized result confirming the hover action.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+
+    [McpServerTool(Name = "browser_select_option")]
+    [Description("Select an option in a dropdown.")]
+    public static async Task<string> BrowserSelectOptionAsync(
+        [Description("Human-readable element description used to obtain permission to interact with the element.")] string element,
+        [Description("Exact target element reference from the page snapshot.")] string elementRef,
+        [Description("Array of values to select in the dropdown. This can be a single value or multiple values.")] string[] values,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for selecting options in a dropdown element.
+        // Pseudocode:
+        // 1. Locate the dropdown element using the provided descriptors.
+        // 2. Select each requested option value within the control.
+        // 3. Return a serialized summary of the selected values.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+
+    [McpServerTool(Name = "browser_snapshot")]
+    [Description("Capture accessibility snapshot of the current page, this is better than screenshot.")]
+    public static async Task<string> BrowserSnapshotAsync(
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for generating an accessibility snapshot.
+        // Pseudocode:
+        // 1. Request the accessibility tree or snapshot from the current page.
+        // 2. Serialize the snapshot data into a structured response.
+        // 3. Return the serialized snapshot payload.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.tabs.cs
+++ b/dotnet/PlaywrightTools.Actions.tabs.cs
@@ -1,0 +1,26 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "browser_tabs")]
+    [Description("List, create, close, or select a browser tab.")]
+    public static async Task<string> BrowserTabsAsync(
+        [Description("Operation to perform.")] string action,
+        [Description("Tab index, used for close/select. If omitted for close, current tab is closed.")] int? index = null,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for managing browser tabs.
+        // Pseudocode:
+        // 1. Interpret the requested tab action (list, create, close, select).
+        // 2. Execute the tab management operation using the browser context.
+        // 3. Return serialized information about the resulting tab state.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.tracing.cs
+++ b/dotnet/PlaywrightTools.Actions.tracing.cs
@@ -1,0 +1,38 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "browser_start_tracing")]
+    [Description("Start trace recording.")]
+    public static async Task<string> BrowserStartTracingAsync(
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for starting browser tracing.
+        // Pseudocode:
+        // 1. Configure tracing parameters and initiate tracing on the context.
+        // 2. Confirm tracing has started successfully.
+        // 3. Return serialized status details about the active trace.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+
+    [McpServerTool(Name = "browser_stop_tracing")]
+    [Description("Stop trace recording.")]
+    public static async Task<string> BrowserStopTracingAsync(
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for stopping browser tracing.
+        // Pseudocode:
+        // 1. Finalize the active trace session and collect artifacts.
+        // 2. Persist or expose the trace results as needed.
+        // 3. Return serialized information summarizing the trace data.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.verify.cs
+++ b/dotnet/PlaywrightTools.Actions.verify.cs
@@ -1,0 +1,76 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "browser_verify_element_visible")]
+    [Description("Verify element is visible on the page.")]
+    public static async Task<string> BrowserVerifyElementVisibleAsync(
+        [Description("ROLE of the element.")] string role,
+        [Description("ACCESSIBLE_NAME of the element.")] string accessibleName,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for verifying element visibility by role and accessible name.
+        // Pseudocode:
+        // 1. Query the accessibility tree for the element matching the criteria.
+        // 2. Confirm the element is visible/present.
+        // 3. Return a serialized verification result with status details.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+
+    [McpServerTool(Name = "browser_verify_text_visible")]
+    [Description("Verify text is visible on the page.")]
+    public static async Task<string> BrowserVerifyTextVisibleAsync(
+        [Description("TEXT to verify. Can be found in the snapshot like this: `- role \"Accessible Name\": {TEXT}` or like this: `- text: {TEXT}`.")] string text,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for checking visibility of arbitrary text.
+        // Pseudocode:
+        // 1. Search the page or accessibility snapshot for the specified text.
+        // 2. Determine whether the text is currently visible.
+        // 3. Return a serialized result describing the verification outcome.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+
+    [McpServerTool(Name = "browser_verify_list_visible")]
+    [Description("Verify list is visible on the page.")]
+    public static async Task<string> BrowserVerifyListVisibleAsync(
+        [Description("Human-readable list description.")] string element,
+        [Description("Exact target element reference that points to the list.")] string elementRef,
+        [Description("Items to verify.")] string[] items,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for validating a list and its contents.
+        // Pseudocode:
+        // 1. Locate the list element via its reference.
+        // 2. Compare the displayed items with the provided list of expected items.
+        // 3. Return serialized verification details including mismatches if any.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+
+    [McpServerTool(Name = "browser_verify_value")]
+    [Description("Verify element value.")]
+    public static async Task<string> BrowserVerifyValueAsync(
+        [Description("Type of the element (`textbox`/`checkbox`/`radio`/`combobox`/`slider`).")] string type,
+        [Description("Human-readable element description.")] string element,
+        [Description("Exact target element reference that points to the element.")] string elementRef,
+        [Description("Value to verify. For checkbox, use \"true\" or \"false\".")] string value,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for validating element values based on type.
+        // Pseudocode:
+        // 1. Locate the element according to the descriptors.
+        // 2. Retrieve the element's current value or state.
+        // 3. Compare with the expected value and return serialized results.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.wait.cs
+++ b/dotnet/PlaywrightTools.Actions.wait.cs
@@ -1,0 +1,27 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    [McpServerTool(Name = "browser_wait_for")]
+    [Description("Wait for text to appear or disappear or a specified time to pass.")]
+    public static async Task<string> BrowserWaitForAsync(
+        [Description("The time to wait in seconds.")] double? time = null,
+        [Description("The text to wait for.")] string? text = null,
+        [Description("The text to wait for to disappear.")] string? textGone = null,
+        CancellationToken cancellationToken = default)
+    {
+        // TODO: Implement tool logic for waiting on page state or content changes.
+        // Pseudocode:
+        // 1. Determine the waiting condition based on provided arguments.
+        // 2. Execute the appropriate wait routine (time delay, text appears, or text disappears).
+        // 3. Return a serialized result summarizing the wait outcome.
+        await Task.CompletedTask;
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
## Summary
- add partial class files under `dotnet` defining MCP tool stubs for the Playwright browser actions catalog
- include the required attributes and pseudocode placeholders for future implementations across navigation, dialogs, input, and verification tools

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e08bfc04d88329b6a3e1edc457226d