### PR TITLE
Add sample login page for demo credentials

### DIFF
--- a/ts/login-example/index.html
+++ b/ts/login-example/index.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>示例登录页</title>
+    <style>
+      body {
+        font-family: "Segoe UI", "PingFang SC", "Helvetica Neue", Arial, sans-serif;
+        background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        min-height: 100vh;
+        margin: 0;
+      }
+
+      .login-card {
+        background-color: #ffffff;
+        border-radius: 12px;
+        box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+        padding: 32px;
+        width: 100%;
+        max-width: 360px;
+      }
+
+      h1 {
+        font-size: 24px;
+        margin: 0 0 24px;
+        text-align: center;
+        color: #333333;
+      }
+
+      label {
+        display: block;
+        margin-bottom: 8px;
+        color: #555555;
+        font-weight: 600;
+      }
+
+      input[type="text"],
+      input[type="password"] {
+        width: 100%;
+        padding: 10px 12px;
+        margin-bottom: 16px;
+        border: 1px solid #dcdcdc;
+        border-radius: 6px;
+        font-size: 14px;
+        transition: border-color 0.2s ease;
+      }
+
+      input[type="text"]:focus,
+      input[type="password"]:focus {
+        border-color: #4f46e5;
+        outline: none;
+        box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.2);
+      }
+
+      button {
+        width: 100%;
+        padding: 12px;
+        background-color: #4f46e5;
+        border: none;
+        border-radius: 6px;
+        color: #ffffff;
+        font-size: 16px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background-color 0.2s ease;
+      }
+
+      button:hover {
+        background-color: #4338ca;
+      }
+
+      .hint {
+        font-size: 13px;
+        color: #888888;
+        margin-top: 12px;
+        text-align: center;
+      }
+
+      .error-message {
+        color: #d93025;
+        text-align: center;
+        margin-bottom: 12px;
+        display: none;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="login-card">
+      <h1>登录示例</h1>
+      <form id="login-form">
+        <label for="username">用户名</label>
+        <input id="username" type="text" name="username" value="demo" autocomplete="username" required />
+
+        <label for="password">密码</label>
+        <input id="password" type="password" name="password" placeholder="请输入密码" autocomplete="current-password" required />
+
+        <p id="error-message" class="error-message">用户名或密码错误，请重试。</p>
+
+        <button type="submit">登录</button>
+      </form>
+      <p class="hint">用户名：demo，密码：123456</p>
+    </main>
+
+    <script>
+      const USERNAME = "demo";
+      const PASSWORD = "123456";
+
+      document.getElementById("login-form").addEventListener("submit", function (event) {
+        event.preventDefault();
+        const username = (document.getElementById("username").value || "").trim();
+        const password = document.getElementById("password").value;
+        const errorMessage = document.getElementById("error-message");
+
+        if (username === USERNAME && password === PASSWORD) {
+          errorMessage.style.display = "none";
+          alert("登录成功，欢迎回来！");
+          window.location.href = "test.html";
+        } else {
+          errorMessage.style.display = "block";
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/ts/login-example/test.html
+++ b/ts/login-example/test.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>测试内页</title>
+    <style>
+      body {
+        font-family: "Segoe UI", "PingFang SC", "Helvetica Neue", Arial, sans-serif;
+        background-color: #f9fafb;
+        margin: 0;
+        padding: 0;
+        color: #1f2933;
+      }
+
+      header {
+        background: linear-gradient(135deg, #6366f1, #8b5cf6);
+        padding: 48px 24px;
+        text-align: center;
+        color: #ffffff;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: 32px;
+        letter-spacing: 1px;
+      }
+
+      main {
+        max-width: 720px;
+        margin: -32px auto 0;
+        background-color: #ffffff;
+        border-radius: 16px;
+        box-shadow: 0 15px 35px rgba(15, 23, 42, 0.12);
+        padding: 32px;
+      }
+
+      p {
+        line-height: 1.7;
+        font-size: 16px;
+        margin-bottom: 16px;
+      }
+
+      a.button {
+        display: inline-block;
+        padding: 12px 24px;
+        background-color: #4f46e5;
+        color: #ffffff;
+        border-radius: 8px;
+        text-decoration: none;
+        font-weight: 600;
+        transition: background-color 0.2s ease;
+      }
+
+      a.button:hover {
+        background-color: #4338ca;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>欢迎来到测试内页</h1>
+      <p>登录成功！这是一个简单的示例页面。</p>
+    </header>
+    <main>
+      <p>
+        这里是登录成功后展示的内容。您可以在实际项目中根据需要，替换为仪表盘、报表或其他功能页面。
+      </p>
+      <p>
+        这是一个示例应用，展示了如何在前端进行简单的用户名和密码校验，并在成功登录后跳转到一个新的页面。
+      </p>
+      <a class="button" href="index.html">返回登录页</a>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a styled login example page under the ts directory
- validate the demo/123456 credentials and redirect to a test inner page on success
- create a simple test page to display after a successful login

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e09c369dc08329a4bba60034d723bd

## Sourcery 总结

添加一个示例登录流程，包含一个用于演示凭据的样式化登录页面和一个相应的登录后测试页面

新功能：
- 引入一个样式化的 HTML 登录示例，用于验证 demo/123456 凭据并在成功后重定向
- 创建一个简单的 test.html 页面，用于在成功登录后显示

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a sample login flow with a styled login page for demo credentials and a corresponding post-login test page

New Features:
- Introduce a styled HTML login example that validates demo/123456 credentials and redirects on success
- Create a simple test.html page to display after successful login

</details>