### PR TITLE
Refactor Playwright MCP runtime for tab and snapshot management

### DIFF
--- a/dotnet/BrowserModels.cs
+++ b/dotnet/BrowserModels.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using Microsoft.Playwright;
+
+namespace PlaywrightMcpServer;
+
+internal sealed record ConsoleMessageEntry
+{
+    [JsonPropertyName("timestamp")] public DateTimeOffset Timestamp { get; init; }
+    [JsonPropertyName("type")] public string Type { get; init; } = string.Empty;
+    [JsonPropertyName("text")] public string Text { get; init; } = string.Empty;
+    [JsonPropertyName("args")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string[]? Args { get; init; }
+}
+
+internal sealed class NetworkRequestEntry
+{
+    [JsonPropertyName("timestamp")] public DateTimeOffset Timestamp { get; init; }
+    [JsonPropertyName("method")] public string Method { get; init; } = string.Empty;
+    [JsonPropertyName("url")] public string Url { get; init; } = string.Empty;
+    [JsonPropertyName("resourceType")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? ResourceType { get; init; }
+    [JsonPropertyName("status")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public int? Status { get; set; }
+    [JsonPropertyName("failure")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? Failure { get; set; }
+
+    public NetworkRequestEntry Clone() => new()
+    {
+        Timestamp = Timestamp,
+        Method = Method,
+        Url = Url,
+        ResourceType = ResourceType,
+        Status = Status,
+        Failure = Failure
+    };
+}
+
+internal sealed record SnapshotPayload
+{
+    [JsonPropertyName("timestamp")] public DateTimeOffset Timestamp { get; init; }
+    [JsonPropertyName("url")] public string Url { get; init; } = string.Empty;
+    [JsonPropertyName("title")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? Title { get; init; }
+    [JsonPropertyName("aria")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public AccessibilitySnapshot? Aria { get; init; }
+    [JsonPropertyName("console")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public IReadOnlyList<ConsoleMessageEntry>? Console { get; init; }
+    [JsonPropertyName("network")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public IReadOnlyList<NetworkRequestEntry>? Network { get; init; }
+}
+
+internal sealed record TabDescriptor
+{
+    [JsonPropertyName("id")] public string Id { get; init; } = string.Empty;
+    [JsonPropertyName("url")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? Url { get; init; }
+    [JsonPropertyName("title")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? Title { get; init; }
+    [JsonPropertyName("isActive")] public bool IsActive { get; init; }
+    [JsonPropertyName("createdAt")] public DateTimeOffset CreatedAt { get; init; }
+}
+
+internal sealed record TabRestoreEntry(string? Url);

--- a/dotnet/PlaywrightMcp_Analysis_Report.md
+++ b/dotnet/PlaywrightMcp_Analysis_Report.md
@@ -1,0 +1,74 @@
+# Playwright MCP 分析与改进方案报告
+
+## 一、TypeScript 版本实现要点综述
+
+| 路径 | 关键职责 |
+| --- | --- |
+| ts/mcp/browser/browserContextFactory.ts | 构建持久化、隔离、远程、CDP 或共享等多种浏览器上下文，同时串联追踪、初始化脚本与退出清理逻辑。 |
+| ts/mcp/browser/context.ts | 统一管理上下文生命周期、标签页列表、模态状态、请求拦截、录制挂钩与产物（视频、追踪、下载）持久化。 |
+| ts/mcp/browser/response.ts | 汇总工具结果、生成代码、快照与图像；在返回 MCP 内容前格式化 Markdown、输出标签页摘要并执行敏感信息脱敏。 |
+| ts/mcp/browser/sessionLog.ts | 将工具调用、用户操作、代码与快照流水化写入 Markdown 会话日志，同时保存快照文件。 |
+| ts/mcp/browser/tab.ts | 表征单个页面，订阅控制台、请求、对话框与下载事件；实现 `_snapshotForAI`，维护模态状态并提供引用定位与等待工具。 |
+| ts/mcp/browser/tools/tool.ts | 统一的工具定义入口，绑定能力元数据与模态状态守卫，再委派至标签页级处理器。 |
+| ts/mcp/browser/tools/utils.ts | 等待协调、定位器解析、无追踪执行与文件名格式化等公共工具逻辑。 |
+| ts/mcp/browser/tools/snapshot.ts | 定义 `browser_snapshot` 及点击、拖拽、悬停、选择、定位器生成等交互工具，产出快照与可执行 Playwright 代码。 |
+| ts/mcp/browser/tools/tabs.ts | 实现 core-tabs 能力，支持列出、新建、关闭与切换标签页并触发快照/标签页摘要更新。 |
+| ts/mcp/browser/tools/evaluate.ts | 在授权引用后执行 `_evaluateFunction`，输出结果、快照与代码片段。 |
+
+**能力特征摘要**
+
+- 快照体系：`tab.ts` 通过 `_snapshotForAI` 汇聚 DOM/ARIA 树、可见文本、控制台、下载等信息，并由 `response.ts` 决定是否嵌入。
+- 上下文/标签页管理：`context.ts` 负责上下文生命周期、模态状态寄存和事件绑定；`tabs.ts` 工具通过能力声明对外暴露多标签控制。
+- 工具注册：`tools.ts` 汇集所有工具，依照配置过滤能力（core/testing/tracing/vision 等），工具元数据包含 type、capability、input schema。
+- 执行模型：工具执行过程中使用 `progress.race()`、`retryWithProgressAndTimeouts()` 等等待/重试策略，确保操作完成与模态状态恢复。
+- 注入脚本：交互工具通过 `injectedScript.evaluate()`、`callOnPageNoTrace()` 等封装实现无痕注入，并生成 Playwright 代码段。
+
+## 二、.NET 版本现状概览
+
+- `dotnet/PlaywrightTools.cs`：集中处理浏览器启动/重启/关闭，当前仅维持单一 `IPage` 实例，事件追踪与状态管理耦合在静态字段中。
+- `dotnet/PlaywrightTools.Actions/*.cs`：多数工具文件仍为 `NotImplementedException` 占位，缺乏实际的快照、交互与返回值封装。
+- `dotnet/mcp` 目录：已搭好类比 TS 的骨架（Context、Tab、Tool 定义、执行服务等），但仍是最小实现，缺乏 Playwright 对象绑定、模态状态守卫及快照整合。
+- `SnapshotBuilder` 等运行时组件只返回占位字符串，未生成结构化 DOM/ARIA 数据，也未与响应聚合流程打通。
+
+## 三、差异分析与改进建议
+
+| 改进方向 | TS 版实践 | .NET 缺口 | 建议措施 |
+| --- | --- | --- | --- |
+| 快照管理 | `tab.ts` 捕获 `_snapshotForAI`，`response.ts` 控制快照嵌入、脱敏与文件落盘。 | `BrowserSnapshotAsync` 未实现，`SnapshotBuilder` 仅返回文本占位。 | 引入 `SnapshotManager`，基于 `IPage.Accessibility.SnapshotAsync` 等 API 生成结构化 JSON，并统一写入响应。 |
+| 标签页/上下文 | `context.ts`/`tab.ts` 维护多页签、模态状态、下载/追踪产物。 | 仅存储 ID 字符串，缺乏真实 `IPage` 绑定与多标签控制。 | 新增 `TabManager`，在 `PlaywrightTools` 中维护页面集合；完善 `Context`/`Tab` 以追踪模态状态与事件。 |
+| 工具元数据 | `defineTool` 提供 type、capability、schema，`tools.ts` 依据配置过滤。 | `ToolHelpers` 输出占位 Markdown，缺乏能力声明。 | 设计 `ToolMetadata` 结构，工具注册时填写 type/capability/schema，并与配置联动过滤。 |
+| 执行模型 | 利用 `progress.race()`、`retryWithProgressAndTimeouts()` 等等待/重试包装工具执行，结束后调用 `Response.finish()`。 | `ToolExecutionService` 仅直接调用处理器，无超时、重试、快照收尾。 | 构建异步封装（等待网络静止、模态清理、可选重试），并将结果注入统一响应对象。 |
+| 脚本注入 | `evaluate.ts` 等通过 `callOnPageNoTrace` 封装脚本执行，具备授权与代码生成。 | `PlaywrightTools.Actions.Evaluate.cs` 未实现，缺少统一注入封装。 | 在扩展方法中封装 `IPage.EvaluateAsync`/`ILocator` 操作，复用到点击、拖拽等交互工具。 |
+
+## 四、融合设计方案
+
+1. **新增核心组件**
+   - `SnapshotManager`：负责收集 ARIA/DOM 树、截图路径、控制台/下载事件，并支持敏感信息脱敏；供所有工具调用。
+   - `TabManager`：管理 `IPage` 实例集合、当前活动标签页、模态状态与事件订阅，支持多标签创建、选择与关闭。
+   - `ToolRegistry`：维护工具元数据（名称、标题、type、capability、schema），提供按能力过滤的注册接口。
+   - `ExecutionOrchestrator`：封装等待/重试策略、超时控制、进度回调，并在执行结束时协调快照/响应合并。
+
+2. **PlaywrightTools 及 Actions 改造**
+   - 将 `PlaywrightTools.cs` 拆分为可注入服务：浏览器上下文工厂、标签页控制、快照服务、工具执行服务。
+   - 补全 `PlaywrightTools.Actions.*` 目录下工具实现，调用上述服务完成快照捕获、事件清理与响应生成。
+   - `Relaunch` 流程需恢复 TabManager 状态，确保支持多标签重连。
+
+3. **迁移/参考的 TS 模块**
+   - `ts/mcp/browser/tab.ts` 与 `context.ts`：参考其模态状态、事件订阅、下载/追踪收集逻辑，映射到 .NET 的 TabManager/Context 中。
+   - `ts/mcp/browser/tools/snapshot.ts`、`tabs.ts`、`evaluate.ts`：对照其工具输入 schema、权限校验与代码生成模式，完善 .NET 对应 Actions。
+   - `ts/mcp/browser/response.ts`：借鉴响应聚合、快照附加与脱敏流程，在 .NET 端建立统一的响应构建器。
+   - `ts/mcp/browser/tools/tool.ts`：对齐工具定义接口，确保 .NET ToolRegistry 支持能力声明与模态守卫。
+
+4. **实施步骤建议**
+   1. 优先实现 SnapshotManager 与基础 TabManager，解除核心工具（snapshot、tabs、navigate、evaluate）的 `NotImplementedException`。
+   2. 引入 ToolMetadata/ToolRegistry，并逐步为工具补全输入 schema 与能力配置，建立与配置文件的联动过滤。
+   3. 构建 ExecutionOrchestrator，将等待/重试逻辑整合进 `ToolExecutionService`，并在响应层添加 `ResponseBuilder`（可参考 TS `Response` 类）。
+   4. 最后扩展测试工具链（verify/wait/testing capability），并接入追踪、截图、PDF 等扩展能力。
+
+## 五、后续行动清单
+
+- [ ] 设计 `SnapshotManager`、`TabManager`、`ToolRegistry`、`ExecutionOrchestrator` 的接口与实现草稿。
+- [ ] 更新 `PlaywrightTools.cs` 与关键 Actions 文件以使用新服务，逐步补齐工具逻辑。
+- [ ] 调整 `dotnet/mcp` 下的 Context、Tab、Tool、Runtime 模块，对接新的服务与响应输出。
+- [ ] 结合配置与能力过滤开展端到端测试，验证多标签快照、模态状态、异步等待等场景。
+

--- a/dotnet/PlaywrightTools.Actions.Relaunch.cs
+++ b/dotnet/PlaywrightTools.Actions.Relaunch.cs
@@ -1,6 +1,4 @@
-﻿using System;
 using System.ComponentModel;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Playwright;
@@ -11,38 +9,86 @@ namespace PlaywrightMcpServer;
 public sealed partial class PlaywrightTools
 {
     /// <summary>
-    /// 重新启动浏览器会话：先彻底关闭现有实例，再按配置重新拉起浏览器并打开新的空白页面。
+    /// 重新启动浏览器会话，可选择浏览器内核，并恢复先前标签页的导航状态。
     /// </summary>
-    /// <param name="cancellationToken">用于在启动过程中取消操作的取消令牌。</param>
-    /// <returns>包含重新启动状态与核心运行信息的 JSON 字符串。</returns>
     [McpServerTool(Name = "browser_relaunch")]
     [Description("(Re)launch browser and open a fresh page.")]
-    public static async Task<string> RelaunchAsync(CancellationToken cancellationToken = default)
+    public static async Task<string> RelaunchAsync(
+        [Description("Browser engine to launch (chromium, firefox, webkit).")] string? engine = null,
+        CancellationToken cancellationToken = default)
     {
+        var restorePlan = TabManager.CreateRestorePlan();
+
+        if (!string.IsNullOrWhiteSpace(engine))
+        {
+            _browserEngine = NormalizeEngine(engine);
+        }
+
         await CloseAsync(cancellationToken).ConfigureAwait(false);
         await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
-        return Serialize(new { relaunched = true, headless = Headless, engine = _isChromium ? "chromium" : "unknown" });
+
+        var context = await GetContextAsync(cancellationToken).ConfigureAwait(false);
+        SnapshotPayload? initialSnapshot = null;
+
+        if (restorePlan.Count > 0)
+        {
+            var activeTab = await GetActiveTabAsync(cancellationToken).ConfigureAwait(false);
+            var first = restorePlan[0];
+            if (!string.IsNullOrWhiteSpace(first.Url))
+            {
+                await activeTab.Page.GotoAsync(first.Url, new PageGotoOptions
+                {
+                    WaitUntil = WaitUntilState.NetworkIdle
+                }).ConfigureAwait(false);
+                initialSnapshot = await SnapshotManager.CaptureAsync(activeTab, cancellationToken).ConfigureAwait(false);
+            }
+
+            for (var index = 1; index < restorePlan.Count; index++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var entry = restorePlan[index];
+                var page = await context.NewPageAsync().ConfigureAwait(false);
+                var tab = TabManager.Register(page, makeActive: false);
+                if (!string.IsNullOrWhiteSpace(entry.Url))
+                {
+                    await page.GotoAsync(entry.Url, new PageGotoOptions
+                    {
+                        WaitUntil = WaitUntilState.NetworkIdle
+                    }).ConfigureAwait(false);
+                    await SnapshotManager.CaptureAsync(tab, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        else
+        {
+            var active = await GetActiveTabAsync(cancellationToken).ConfigureAwait(false);
+            initialSnapshot = await SnapshotManager.CaptureAsync(active, cancellationToken).ConfigureAwait(false);
+        }
+
+        var response = new
+        {
+            relaunched = true,
+            headless = Headless,
+            engine = _browserEngine,
+            tabs = TabManager.DescribeTabs(),
+            snapshot = initialSnapshot
+        };
+
+        return Serialize(response);
     }
 
     /// <summary>
-    /// 关闭并释放当前 Playwright 会话涉及的页面、上下文和浏览器等所有资源，确保不会留下后台进程。
+    /// 关闭并释放当前 Playwright 实例及其上下文、页面等资源。
     /// </summary>
-    /// <param name="cancellationToken">用于在需要时取消关闭流程的取消令牌。</param>
-    /// <returns>表示关闭结果的 JSON 字符串。</returns>
     [McpServerTool(Name = "browser_close")]
     [Description("Close and dispose Playwright browser resources.")]
     public static async Task<string> CloseAsync(CancellationToken cancellationToken = default)
     {
-        if (_page is not null)
-        {
-            DetachPageEventHandlers(_page);
-            try { await _page.CloseAsync().ConfigureAwait(false); }
-            catch { }
-            _page = null;
-        }
+        cancellationToken.ThrowIfCancellationRequested();
 
         if (_context is not null)
         {
+            _context.Page -= ContextOnPage;
             try { await _context.CloseAsync().ConfigureAwait(false); }
             catch { }
             _context = null;
@@ -61,8 +107,25 @@ public sealed partial class PlaywrightTools
             _playwright = null;
         }
 
-        _isChromium = false;
+        TabManager.Reset();
         _tracingActive = false;
+
         return Serialize(new { closed = true });
+    }
+
+    private static string NormalizeEngine(string? engine)
+    {
+        if (string.IsNullOrWhiteSpace(engine))
+        {
+            return "chromium";
+        }
+
+        return engine.Trim().ToLowerInvariant() switch
+        {
+            "chromium" or "chrome" or "msedge" or "edge" => "chromium",
+            "firefox" or "ff" => "firefox",
+            "webkit" or "safari" => "webkit",
+            _ => "chromium"
+        };
     }
 }

--- a/dotnet/PlaywrightTools.cs
+++ b/dotnet/PlaywrightTools.cs
@@ -1,10 +1,15 @@
-using ChatUiTest.Playwright.Helper;
-using Microsoft.Playwright;
-using ModelContextProtocol.Server;
-using System.Diagnostics.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using ChatUiTest.Playwright.Helper;
+using Microsoft.Playwright;
+using ModelContextProtocol.Server;
 
 namespace PlaywrightMcpServer;
 
@@ -18,16 +23,23 @@ public sealed partial class PlaywrightTools
     };
 
     private static readonly object Gate = new();
+    private static readonly SnapshotManager SnapshotManager = new();
+    private static readonly TabManager TabManager = new();
+    private static readonly Dictionary<string, ToolMetadata> ToolRegistry = new(StringComparer.OrdinalIgnoreCase);
+
     private static IPlaywright? _playwright;
     private static IBrowser? _browser;
     private static IBrowserContext? _context;
-    private static IPage? _page;
-    private static bool _isChromium;
+    private static string _browserEngine = "chromium";
     private static bool _tracingActive;
 
-    private static readonly List<ConsoleMessageEntry> ConsoleMessages = new();
-    private static readonly List<NetworkRequestEntry> NetworkRequests = new();
-    private static readonly Dictionary<IRequest, NetworkRequestEntry> NetworkRequestMap = new();
+    static PlaywrightTools()
+    {
+        RegisterTool(new ToolMetadata("browser_relaunch", "(Re)launch browser and open a fresh page.", "action", "core-install"));
+        RegisterTool(new ToolMetadata("browser_close", "Close and dispose Playwright browser resources.", "action", "core"));
+        RegisterTool(new ToolMetadata("browser_navigate", "Navigate to a URL.", "action", "core"));
+        RegisterTool(new ToolMetadata("browser_navigate_back", "Go back to the previous page.", "action", "core"));
+    }
 
     private static bool Headless =>
         (Environment.GetEnvironmentVariable("MCP_PLAYWRIGHT_HEADLESS") ?? "false")
@@ -54,50 +66,87 @@ public sealed partial class PlaywrightTools
 
     private static async Task EnsureLaunchedAsync(CancellationToken cancellationToken)
     {
-        if (_page is { IsClosed: true })
-            _page = null;
-        if (_page is not null)
-            return;
-
+        cancellationToken.ThrowIfCancellationRequested();
         EnsureDirectories();
 
         _playwright ??= await Microsoft.Playwright.Playwright.CreateAsync().ConfigureAwait(false);
 
         if (_browser is null)
         {
-            _browser = await _playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+            _browser = await LaunchBrowserAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        if (_context is null)
+        {
+            _context = await _browser.NewContextAsync(new BrowserNewContextOptions
             {
-                Headless = Headless,
-                Channel = "msedge"
+                AcceptDownloads = true,
+                RecordVideoDir = VideosDir,
+                ViewportSize = new ViewportSize { Width = 1280, Height = 800 },
+                Geolocation = new Geolocation { Latitude = 0, Longitude = 0 }
             }).ConfigureAwait(false);
-            _isChromium = true;
+
+            _context.Page += ContextOnPage;
+            await _context.GrantAllPermissionsAsync().ConfigureAwait(false);
+
+            foreach (var page in _context.Pages.Where(p => !p.IsClosed))
+            {
+                TabManager.Register(page, makeActive: TabManager.ActiveTab is null);
+            }
         }
 
-        if (_context is not null)
+        var active = TabManager.ActiveTab;
+        if (active is null || active.Page.IsClosed)
         {
-            try { await _context.CloseAsync().ConfigureAwait(false); }
-            catch { }
-            _context = null;
+            var page = await _context.NewPageAsync().ConfigureAwait(false);
+            active = TabManager.Register(page, makeActive: true);
         }
 
-        _context = await _browser.NewContextAsync(new BrowserNewContextOptions
+        TabManager.Activate(active);
+    }
+
+    private static async Task<IBrowser> LaunchBrowserAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var options = new BrowserTypeLaunchOptions
         {
-            AcceptDownloads = true,
-            RecordVideoDir = VideosDir,
-            ViewportSize = new ViewportSize { Width = 1280, Height = 800 },
-            Geolocation = new Geolocation { Latitude = 0, Longitude = 0 }
-        }).ConfigureAwait(false);
+            Headless = Headless
+        };
 
-        await _context.GrantAllPermissionsAsync().ConfigureAwait(false);
+        return _browserEngine switch
+        {
+            "firefox" => await _playwright!.Firefox.LaunchAsync(options).ConfigureAwait(false),
+            "webkit" => await _playwright!.Webkit.LaunchAsync(options).ConfigureAwait(false),
+            _ => await LaunchChromiumAsync(options).ConfigureAwait(false)
+        };
+    }
 
-        var page = await _context.NewPageAsync().ConfigureAwait(false);
-        SetActivePage(page);
+    private static async Task<IBrowser> LaunchChromiumAsync(BrowserTypeLaunchOptions options)
+    {
+        // If the environment specifies a channel prefer it, otherwise default to Microsoft Edge similar to TS runtime.
+        var channel = Environment.GetEnvironmentVariable("MCP_PLAYWRIGHT_CHROMIUM_CHANNEL");
+        if (!string.IsNullOrWhiteSpace(channel))
+        {
+            options.Channel = channel;
+        }
+        else if (OperatingSystem.IsWindows() || OperatingSystem.IsLinux())
+        {
+            options.Channel = "msedge";
+        }
+
+        return await _playwright!.Chromium.LaunchAsync(options).ConfigureAwait(false);
     }
 
     private static async Task<IPage> GetPageAsync(CancellationToken cancellationToken)
     {
         await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
-        return _page ?? throw new InvalidOperationException("Active page not initialized.");
+        return TabManager.ActiveTab?.Page ?? throw new InvalidOperationException("Active page not initialized.");
+    }
+
+    private static async Task<TabState> GetActiveTabAsync(CancellationToken cancellationToken)
+    {
+        await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
+        return TabManager.ActiveTab ?? throw new InvalidOperationException("Active tab not available.");
     }
 
     private static async Task<IBrowserContext> GetContextAsync(CancellationToken cancellationToken)
@@ -125,127 +174,32 @@ public sealed partial class PlaywrightTools
             : Path.Combine(basePath, outputPath));
     }
 
-    private static void SetActivePage(IPage page)
+    private static void ContextOnPage(object? sender, IPage page)
     {
-        if (_page == page)
-            return;
-
-        if (_page is not null)
-            DetachPageEventHandlers(_page);
-
-        _page = page;
-
-        lock (ConsoleMessages)
-        {
-            ConsoleMessages.Clear();
-        }
-
-        lock (NetworkRequests)
-        {
-            NetworkRequests.Clear();
-            NetworkRequestMap.Clear();
-        }
-
-        AttachPageEventHandlers(page);
+        TabManager.Register(page, makeActive: false);
     }
 
-    private static void AttachPageEventHandlers(IPage page)
+    public static SnapshotPayload? TryGetLastSnapshot()
     {
-        page.Console += PageOnConsole;
-        page.Request += PageOnRequest;
-        page.Response += PageOnResponse;
-        page.RequestFailed += PageOnRequestFailed;
+        return TabManager.ActiveTab?.LastSnapshot;
     }
 
-    private static void DetachPageEventHandlers(IPage page)
+    public static async Task<SnapshotPayload> GetAriaSnapshotAsync(CancellationToken cancellationToken = default)
     {
-        page.Console -= PageOnConsole;
-        page.Request -= PageOnRequest;
-        page.Response -= PageOnResponse;
-        page.RequestFailed -= PageOnRequestFailed;
+        var tab = await GetActiveTabAsync(cancellationToken).ConfigureAwait(false);
+        return await SnapshotManager.CaptureAsync(tab, cancellationToken).ConfigureAwait(false);
     }
 
-    private static void PageOnConsole(object? sender, IConsoleMessage message)
+    public static IReadOnlyList<TabDescriptor> DescribeTabs()
     {
-        var entry = new ConsoleMessageEntry
-        {
-            Timestamp = DateTimeOffset.UtcNow,
-            Type = message.Type,
-            Text = message.Text,
-            Args = message.Args.Select(arg => arg.ToString()).Where(arg => arg is not null).Cast<string>().ToArray()
-        };
-
-        lock (ConsoleMessages)
-        {
-            ConsoleMessages.Add(entry);
-            if (ConsoleMessages.Count > 200)
-                ConsoleMessages.RemoveAt(0);
-        }
+        return TabManager.DescribeTabs();
     }
 
-    private static void PageOnRequest(object? sender, IRequest request)
-    {
-        var entry = new NetworkRequestEntry
-        {
-            Timestamp = DateTimeOffset.UtcNow,
-            Method = request.Method,
-            Url = request.Url,
-            ResourceType = request.ResourceType,
-            Failure = null,
-            Status = null
-        };
+    internal static IReadOnlyDictionary<string, ToolMetadata> RegisteredToolMetadata => ToolRegistry;
 
-        lock (NetworkRequests)
-        {
-            NetworkRequests.Add(entry);
-            NetworkRequestMap[request] = entry;
-            if (NetworkRequests.Count > 500)
-            {
-                var first = NetworkRequests.First();
-                NetworkRequests.RemoveAt(0);
-                var keyToRemove = NetworkRequestMap.FirstOrDefault(kvp => kvp.Value == first).Key;
-                if (keyToRemove is not null)
-                    NetworkRequestMap.Remove(keyToRemove);
-            }
-        }
-    }
-
-    private static void PageOnResponse(object? sender, IResponse response)
+    private static void RegisterTool(ToolMetadata metadata)
     {
-        lock (NetworkRequests)
-        {
-            if (NetworkRequestMap.TryGetValue(response.Request, out var entry))
-            {
-                entry.Status = response.Status;
-            }
-        }
-    }
-
-    private static void PageOnRequestFailed(object? sender, IRequest request)
-    {
-        lock (NetworkRequests)
-        {
-            if (NetworkRequestMap.TryGetValue(request, out var entry))
-            {
-                entry.Failure = request.Failure;
-            }
-        }
-    }
-
-    private static ConsoleMessageEntry[] SnapshotConsoleMessages()
-    {
-        lock (ConsoleMessages)
-        {
-            return ConsoleMessages.ToArray();
-        }
-    }
-
-    private static NetworkRequestEntry[] SnapshotNetworkRequests()
-    {
-        lock (NetworkRequests)
-        {
-            return NetworkRequests.Select(r => r.Clone()).ToArray();
-        }
+        ToolRegistry[metadata.Name] = metadata;
     }
 
     private static void EnsureDirectories()
@@ -260,71 +214,26 @@ public sealed partial class PlaywrightTools
         }
     }
 
-    private static int GetPageIndex(IPage page)
-    {
-        if (_context is null)
-            return -1;
-
-        var match = _context.Pages
-            .Select((p, idx) => new { Page = p, Index = idx })
-            .FirstOrDefault(tuple => tuple.Page == page);
-        return match?.Index ?? -1;
-    }
-
-    #region helpers
-
-    public sealed record ConsoleMessageEntry
-    {
-        [JsonPropertyName("timestamp")] public DateTimeOffset Timestamp { get; init; }
-        [JsonPropertyName("type")] public string Type { get; init; } = string.Empty;
-        [JsonPropertyName("text")] public string Text { get; init; } = string.Empty;
-        [JsonPropertyName("args")][AllowNull] public string[]? Args { get; init; }
-    }
-
-    public sealed class NetworkRequestEntry
-    {
-        [JsonPropertyName("timestamp")] public DateTimeOffset Timestamp { get; init; }
-        [JsonPropertyName("method")] public string Method { get; init; } = string.Empty;
-        [JsonPropertyName("url")] public string Url { get; init; } = string.Empty;
-        [JsonPropertyName("resourceType")][AllowNull] public string? ResourceType { get; init; }
-        [JsonPropertyName("status")][AllowNull] public int? Status { get; set; }
-        [JsonPropertyName("failure")][AllowNull] public string? Failure { get; set; }
-
-        public NetworkRequestEntry Clone() => new()
-        {
-            Timestamp = Timestamp,
-            Method = Method,
-            Url = Url,
-            ResourceType = ResourceType,
-            Status = Status,
-            Failure = Failure
-        };
-    }
-
-    // ----------------------
-    // Helper methods (本文件内提供，解决“当前上下文中不存在名称 ...”)
-    // ----------------------
-
     private static MouseButton? ParseMouseButton(string? button)
     {
         if (string.IsNullOrWhiteSpace(button)) return null;
-        switch (button.Trim().ToLowerInvariant())
+        return button.Trim().ToLowerInvariant() switch
         {
-            case "left": return MouseButton.Left;
-            case "middle": return MouseButton.Middle;
-            case "right": return MouseButton.Right;
-            default: return null; // 未识别则交给 Playwright 默认（Left）
-        }
+            "left" => MouseButton.Left,
+            "middle" => MouseButton.Middle,
+            "right" => MouseButton.Right,
+            _ => null
+        };
     }
 
     private static IEnumerable<KeyboardModifier>? ParseModifiers(string[]? modifiers)
     {
-        if (modifiers == null || modifiers.Length == 0) return null;
+        if (modifiers is null || modifiers.Length == 0) return null;
 
         var list = new List<KeyboardModifier>(modifiers.Length);
-        foreach (var m in modifiers)
+        foreach (var modifier in modifiers)
         {
-            switch (m)
+            switch (modifier)
             {
                 case "Alt":
                     list.Add(KeyboardModifier.Alt);
@@ -344,13 +253,32 @@ public sealed partial class PlaywrightTools
                         : KeyboardModifier.Control);
                     break;
                 default:
-                    // 忽略未知修饰键，保持宽容
                     break;
             }
         }
-        // 去重
+
         return list.Distinct().ToArray();
     }
 
-    #endregion
+    private static string NormalizeUrl(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            throw new ArgumentException("URL must not be empty.", nameof(url));
+        }
+
+        if (Uri.TryCreate(url, UriKind.Absolute, out var absolute))
+        {
+            return absolute.ToString();
+        }
+
+        if (Uri.TryCreate($"https://{url}", UriKind.Absolute, out var https))
+        {
+            return https.ToString();
+        }
+
+        throw new ArgumentException("Invalid URL format.", nameof(url));
+    }
+
+    internal sealed record ToolMetadata(string Name, string Title, string Type, string Capability);
 }

--- a/dotnet/SnapshotManager.cs
+++ b/dotnet/SnapshotManager.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
+namespace PlaywrightMcpServer;
+
+internal sealed class SnapshotManager
+{
+    public async Task<SnapshotPayload> CaptureAsync(TabState tab, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(tab);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var page = tab.Page;
+        AccessibilitySnapshot? aria = null;
+        try
+        {
+            aria = await page.Accessibility.SnapshotAsync(new AccessibilitySnapshotOptions
+            {
+                InterestingOnly = false
+            }).ConfigureAwait(false);
+        }
+        catch (PlaywrightException)
+        {
+            // Fallback: still produce snapshot metadata when accessibility tree is unavailable.
+        }
+
+        var title = await page.TitleAsync().ConfigureAwait(false);
+        var url = page.Url ?? string.Empty;
+        var (console, network) = tab.TakeActivitySnapshot();
+
+        var snapshot = new SnapshotPayload
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Url = url,
+            Title = title,
+            Aria = aria,
+            Console = console,
+            Network = network
+        };
+
+        tab.UpdateMetadata(url, title, snapshot);
+        return snapshot;
+    }
+}

--- a/dotnet/TabManager.cs
+++ b/dotnet/TabManager.cs
@@ -1,0 +1,306 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Microsoft.Playwright;
+
+namespace PlaywrightMcpServer;
+
+internal sealed class TabManager
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<IPage, TabState> _tabs = new(new ReferenceEqualityComparer<IPage>());
+    private TabState? _activeTab;
+    private int _sequence;
+
+    public TabState? ActiveTab
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _activeTab;
+            }
+        }
+    }
+
+    public IReadOnlyList<TabState> Tabs
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _tabs.Values.OrderBy(t => t.CreatedAt).ToArray();
+            }
+        }
+    }
+
+    public TabState Register(IPage page, bool makeActive = true)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        TabState tab;
+        bool attachHandlers = false;
+        lock (_gate)
+        {
+            if (!_tabs.TryGetValue(page, out tab!))
+            {
+                tab = new TabState(page, $"tab-{++_sequence}", DateTimeOffset.UtcNow, Remove);
+                _tabs.Add(page, tab);
+                attachHandlers = true;
+            }
+
+            if (makeActive || _activeTab is null)
+            {
+                _activeTab = tab;
+            }
+        }
+
+        if (attachHandlers)
+        {
+            tab.AttachHandlers();
+        }
+
+        return tab;
+    }
+
+    public void Activate(IPage page)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+        lock (_gate)
+        {
+            if (_tabs.TryGetValue(page, out var tab))
+            {
+                _activeTab = tab;
+            }
+        }
+    }
+
+    public void Activate(TabState tab)
+    {
+        ArgumentNullException.ThrowIfNull(tab);
+        lock (_gate)
+        {
+            if (_tabs.ContainsKey(tab.Page))
+            {
+                _activeTab = tab;
+            }
+        }
+    }
+
+    public IReadOnlyList<TabDescriptor> DescribeTabs()
+    {
+        lock (_gate)
+        {
+            return _tabs.Values
+                .OrderBy(t => t.CreatedAt)
+                .Select(t => t.ToDescriptor(ReferenceEquals(t, _activeTab)))
+                .ToArray();
+        }
+    }
+
+    public IReadOnlyList<TabRestoreEntry> CreateRestorePlan()
+    {
+        lock (_gate)
+        {
+            return _tabs.Values
+                .OrderBy(t => t.CreatedAt)
+                .Select(t => new TabRestoreEntry(t.Url))
+                .ToArray();
+        }
+    }
+
+    public void Remove(TabState tab)
+    {
+        ArgumentNullException.ThrowIfNull(tab);
+        lock (_gate)
+        {
+            if (_tabs.Remove(tab.Page))
+            {
+                tab.Dispose();
+                if (ReferenceEquals(tab, _activeTab))
+                {
+                    _activeTab = _tabs.Values.OrderBy(t => t.CreatedAt).FirstOrDefault();
+                }
+            }
+        }
+    }
+
+    public void Reset()
+    {
+        lock (_gate)
+        {
+            foreach (var tab in _tabs.Values)
+            {
+                tab.Dispose();
+            }
+
+            _tabs.Clear();
+            _activeTab = null;
+            _sequence = 0;
+        }
+    }
+}
+
+internal sealed class TabState : IDisposable
+{
+    private readonly object _gate = new();
+    private readonly List<ConsoleMessageEntry> _consoleMessages = new();
+    private readonly List<NetworkRequestEntry> _networkRequests = new();
+    private readonly Dictionary<IRequest, NetworkRequestEntry> _requestMap = new(new ReferenceEqualityComparer<IRequest>());
+    private readonly Action<TabState> _onClosed;
+
+    private readonly EventHandler<IConsoleMessage> _consoleHandler;
+    private readonly EventHandler<IRequest> _requestHandler;
+    private readonly EventHandler<IResponse> _responseHandler;
+    private readonly EventHandler<IRequest> _requestFailedHandler;
+    private readonly EventHandler _closeHandler;
+
+    public TabState(IPage page, string id, DateTimeOffset createdAt, Action<TabState> onClosed)
+    {
+        Page = page ?? throw new ArgumentNullException(nameof(page));
+        Id = id ?? throw new ArgumentNullException(nameof(id));
+        CreatedAt = createdAt;
+        _onClosed = onClosed ?? throw new ArgumentNullException(nameof(onClosed));
+
+        _consoleHandler = (_, message) =>
+        {
+            var entry = new ConsoleMessageEntry
+            {
+                Timestamp = DateTimeOffset.UtcNow,
+                Type = message.Type,
+                Text = message.Text,
+                Args = message.Args.Select(arg => arg.ToString()).Where(arg => arg is not null).Cast<string>().ToArray()
+            };
+
+            lock (_gate)
+            {
+                _consoleMessages.Add(entry);
+                if (_consoleMessages.Count > 200)
+                {
+                    _consoleMessages.RemoveAt(0);
+                }
+            }
+        };
+
+        _requestHandler = (_, request) =>
+        {
+            var entry = new NetworkRequestEntry
+            {
+                Timestamp = DateTimeOffset.UtcNow,
+                Method = request.Method,
+                Url = request.Url,
+                ResourceType = request.ResourceType
+            };
+
+            lock (_gate)
+            {
+                _networkRequests.Add(entry);
+                _requestMap[request] = entry;
+                if (_networkRequests.Count > 500)
+                {
+                    var oldest = _networkRequests.First();
+                    _networkRequests.RemoveAt(0);
+                    var toRemove = _requestMap.FirstOrDefault(kvp => kvp.Value == oldest).Key;
+                    if (toRemove is not null)
+                    {
+                        _requestMap.Remove(toRemove);
+                    }
+                }
+            }
+        };
+
+        _responseHandler = (_, response) =>
+        {
+            lock (_gate)
+            {
+                if (_requestMap.TryGetValue(response.Request, out var entry))
+                {
+                    entry.Status = response.Status;
+                }
+            }
+        };
+
+        _requestFailedHandler = (_, request) =>
+        {
+            lock (_gate)
+            {
+                if (_requestMap.TryGetValue(request, out var entry))
+                {
+                    entry.Failure = request.Failure;
+                }
+            }
+        };
+
+        _closeHandler = (_, _) => _onClosed(this);
+    }
+
+    public string Id { get; }
+    public IPage Page { get; }
+    public DateTimeOffset CreatedAt { get; }
+    public string? Title { get; private set; }
+    public string? Url { get; private set; }
+    public SnapshotPayload? LastSnapshot { get; private set; }
+
+    public void AttachHandlers()
+    {
+        Page.Console += _consoleHandler;
+        Page.Request += _requestHandler;
+        Page.Response += _responseHandler;
+        Page.RequestFailed += _requestFailedHandler;
+        Page.Close += _closeHandler;
+        Url = Page.Url;
+    }
+
+    public void Dispose()
+    {
+        Page.Console -= _consoleHandler;
+        Page.Request -= _requestHandler;
+        Page.Response -= _responseHandler;
+        Page.RequestFailed -= _requestFailedHandler;
+        Page.Close -= _closeHandler;
+    }
+
+    public (IReadOnlyList<ConsoleMessageEntry> console, IReadOnlyList<NetworkRequestEntry> network) TakeActivitySnapshot()
+    {
+        lock (_gate)
+        {
+            return (
+                _consoleMessages.ToArray(),
+                _networkRequests.Select(entry => entry.Clone()).ToArray());
+        }
+    }
+
+    public void UpdateMetadata(string? url, string? title, SnapshotPayload snapshot)
+    {
+        lock (_gate)
+        {
+            Url = url;
+            Title = title;
+            LastSnapshot = snapshot;
+        }
+    }
+
+    public TabDescriptor ToDescriptor(bool isActive)
+    {
+        lock (_gate)
+        {
+            return new TabDescriptor
+            {
+                Id = Id,
+                Url = Url,
+                Title = Title,
+                IsActive = isActive,
+                CreatedAt = CreatedAt
+            };
+        }
+    }
+}
+
+internal sealed class ReferenceEqualityComparer<T> : IEqualityComparer<T>
+    where T : class
+{
+    public bool Equals(T? x, T? y) => ReferenceEquals(x, y);
+
+    public int GetHashCode(T obj) => RuntimeHelpers.GetHashCode(obj);
+}


### PR DESCRIPTION
## Summary
- refactor the Playwright MCP runtime to centralize browser launch, tab tracking, and tool metadata registration
- add dedicated snapshot and tab manager components that capture accessibility, console, and network data per tab
- implement relaunch and navigation actions with engine selection, tab restoration, and automatic snapshot capture

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e2837d49808329804aa8235cfb4df1

## Sourcery 总结

重构 Playwright 运行时，以支持多标签页管理、集中式浏览器和工具注册以及自动化快照捕获，从而改进导航和重新启动工作流。

新功能：
- 添加 TabManager 以支持多标签页和快照跟踪
- 引入 SnapshotManager 用于捕获每个标签页的可访问性、控制台和网络数据
- 实现 browser_relaunch 操作，支持引擎选择和自动会话恢复
- 实现 browser_navigate 和 browser_navigate_back 操作，支持 URL 规范化和自动快照

改进：
- 集中化浏览器启动、上下文设置和工具元数据注册
- 建立 ToolRegistry 用于工具的动态元数据注册
- 将 PlaywrightTools 重构为模块化组件（TabManager、SnapshotManager、浏览器模型）

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the Playwright runtime to support multi-tab management, centralized browser and tool registration, and automated snapshot capture for improved navigation and relaunch workflows

New Features:
- Add TabManager for multi-tab support and snapshot tracking
- Introduce SnapshotManager for capturing accessibility, console, and network data per tab
- Implement browser_relaunch action with engine selection and automatic session restore
- Implement browser_navigate and browser_navigate_back actions with URL normalization and automatic snapshots

Enhancements:
- Centralize browser launch, context setup, and tool metadata registration
- Establish ToolRegistry for dynamic metadata registration of tools
- Refactor PlaywrightTools into modular components (TabManager, SnapshotManager, browser models)

</details>