### PR TITLE
Fix serialization of accessibility snapshot data

### DIFF
--- a/dotnet/BrowserModels.cs
+++ b/dotnet/BrowserModels.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Playwright;
 
@@ -38,7 +39,7 @@ internal sealed record SnapshotPayload
     [JsonPropertyName("timestamp")] public DateTimeOffset Timestamp { get; init; }
     [JsonPropertyName("url")] public string Url { get; init; } = string.Empty;
     [JsonPropertyName("title")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? Title { get; init; }
-    [JsonPropertyName("aria")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public AccessibilitySnapshot? Aria { get; init; }
+    [JsonPropertyName("aria")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public JsonElement? Aria { get; init; }
     [JsonPropertyName("console")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public IReadOnlyList<ConsoleMessageEntry>? Console { get; init; }
     [JsonPropertyName("network")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public IReadOnlyList<NetworkRequestEntry>? Network { get; init; }
 }

--- a/dotnet/SnapshotManager.cs
+++ b/dotnet/SnapshotManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Playwright;
@@ -13,13 +14,18 @@ internal sealed class SnapshotManager
         cancellationToken.ThrowIfCancellationRequested();
 
         var page = tab.Page;
-        AccessibilitySnapshot? aria = null;
+        JsonElement? aria = null;
         try
         {
-            aria = await page.Accessibility.SnapshotAsync(new AccessibilitySnapshotOptions
+            var snapshot = await page.Accessibility.SnapshotAsync(new AccessibilitySnapshotOptions
             {
                 InterestingOnly = false
             }).ConfigureAwait(false);
+
+            if (snapshot is not null)
+            {
+                aria = JsonSerializer.SerializeToElement(snapshot, snapshot.GetType());
+            }
         }
         catch (PlaywrightException)
         {


### PR DESCRIPTION
## Summary
- store accessibility snapshot data as JsonElement rather than referencing an undefined AccessibilitySnapshot type
- convert the Playwright snapshot result into a JsonElement before returning it in the payload

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e294b3af84832984b629143538c862