### PR TITLE
Resolve snapshot variable naming conflict

### DIFF
--- a/dotnet/BrowserModels.cs
+++ b/dotnet/BrowserModels.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Playwright;
 
@@ -38,7 +39,7 @@ internal sealed record SnapshotPayload
     [JsonPropertyName("timestamp")] public DateTimeOffset Timestamp { get; init; }
     [JsonPropertyName("url")] public string Url { get; init; } = string.Empty;
     [JsonPropertyName("title")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? Title { get; init; }
-    [JsonPropertyName("aria")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public AccessibilitySnapshot? Aria { get; init; }
+    [JsonPropertyName("aria")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public JsonElement? Aria { get; init; }
     [JsonPropertyName("console")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public IReadOnlyList<ConsoleMessageEntry>? Console { get; init; }
     [JsonPropertyName("network")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public IReadOnlyList<NetworkRequestEntry>? Network { get; init; }
 }

--- a/dotnet/SnapshotManager.cs
+++ b/dotnet/SnapshotManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Playwright;
@@ -13,13 +14,18 @@ internal sealed class SnapshotManager
         cancellationToken.ThrowIfCancellationRequested();
 
         var page = tab.Page;
-        AccessibilitySnapshot? aria = null;
+        JsonElement? aria = null;
         try
         {
-            aria = await page.Accessibility.SnapshotAsync(new AccessibilitySnapshotOptions
+            var accessibilitySnapshot = await page.Accessibility.SnapshotAsync(new AccessibilitySnapshotOptions
             {
                 InterestingOnly = false
             }).ConfigureAwait(false);
+
+            if (accessibilitySnapshot is not null)
+            {
+                aria = JsonSerializer.SerializeToElement(accessibilitySnapshot, accessibilitySnapshot.GetType());
+            }
         }
         catch (PlaywrightException)
         {


### PR DESCRIPTION
## Summary
- rename the accessibility snapshot local variable to avoid clashing with the payload variable
- ensure serialization uses the renamed variable when present

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e294b3af84832984b629143538c862

## Sourcery 总结

重命名可访问性快照变量并更改其类型，以避免命名冲突并确保正确地将 JSON 序列化到有效负载中

改进:
- 将本地的 `AccessibilitySnapshot? aria` 替换为 `JsonElement? aria`，并在存在时将可访问性快照序列化为 `JsonElement`
- 将本地可访问性快照变量重命名为 `accessibilitySnapshot` 以提高清晰度
- 更新 `SnapshotPayload.Aria` 属性为 `JsonElement?` 以匹配新的序列化类型

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rename and change type of the accessibility snapshot variable to avoid naming conflicts and ensure proper JSON serialization into the payload

Enhancements:
- Replace local AccessibilitySnapshot? aria with a JsonElement? aria and serialize the accessibility snapshot to JsonElement when present
- Rename the local accessibility snapshot variable to accessibilitySnapshot for clarity
- Update SnapshotPayload.Aria property to JsonElement? to match the new serialization type

</details>