### PR TITLE
Handle deprecated accessibility snapshot APIs

### DIFF
--- a/dotnet/BrowserModels.cs
+++ b/dotnet/BrowserModels.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Playwright;
 
@@ -38,7 +39,7 @@ internal sealed record SnapshotPayload
     [JsonPropertyName("timestamp")] public DateTimeOffset Timestamp { get; init; }
     [JsonPropertyName("url")] public string Url { get; init; } = string.Empty;
     [JsonPropertyName("title")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? Title { get; init; }
-    [JsonPropertyName("aria")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public AccessibilitySnapshot? Aria { get; init; }
+    [JsonPropertyName("aria")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public JsonElement? Aria { get; init; }
     [JsonPropertyName("console")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public IReadOnlyList<ConsoleMessageEntry>? Console { get; init; }
     [JsonPropertyName("network")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public IReadOnlyList<NetworkRequestEntry>? Network { get; init; }
 }


### PR DESCRIPTION
## Summary
- switch SnapshotManager to call the new page-level AccessibilitySnapshotAsync API when available
- fall back to the legacy IAccessibility.SnapshotAsync implementation via reflection for older Playwright versions
- keep snapshot serialization logic unchanged while avoiding obsolete member usage

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e294b3af84832984b629143538c862