### PR TITLE
Fix Playwright tools accessibility and permissions

### DIFF
--- a/dotnet/BrowserModels.cs
+++ b/dotnet/BrowserModels.cs
@@ -6,7 +6,7 @@ using Microsoft.Playwright;
 
 namespace PlaywrightMcpServer;
 
-internal sealed record ConsoleMessageEntry
+public sealed record ConsoleMessageEntry
 {
     [JsonPropertyName("timestamp")] public DateTimeOffset Timestamp { get; init; }
     [JsonPropertyName("type")] public string Type { get; init; } = string.Empty;
@@ -14,7 +14,7 @@ internal sealed record ConsoleMessageEntry
     [JsonPropertyName("args")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string[]? Args { get; init; }
 }
 
-internal sealed class NetworkRequestEntry
+public sealed class NetworkRequestEntry
 {
     [JsonPropertyName("timestamp")] public DateTimeOffset Timestamp { get; init; }
     [JsonPropertyName("method")] public string Method { get; init; } = string.Empty;
@@ -34,7 +34,7 @@ internal sealed class NetworkRequestEntry
     };
 }
 
-internal sealed record SnapshotPayload
+public sealed record SnapshotPayload
 {
     [JsonPropertyName("timestamp")] public DateTimeOffset Timestamp { get; init; }
     [JsonPropertyName("url")] public string Url { get; init; } = string.Empty;
@@ -44,7 +44,7 @@ internal sealed record SnapshotPayload
     [JsonPropertyName("network")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public IReadOnlyList<NetworkRequestEntry>? Network { get; init; }
 }
 
-internal sealed record TabDescriptor
+public sealed record TabDescriptor
 {
     [JsonPropertyName("id")] public string Id { get; init; } = string.Empty;
     [JsonPropertyName("url")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? Url { get; init; }

--- a/dotnet/PlaywrightTools.cs
+++ b/dotnet/PlaywrightTools.cs
@@ -7,7 +7,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using ChatUiTest.Playwright.Helper;
 using Microsoft.Playwright;
 using ModelContextProtocol.Server;
 
@@ -87,7 +86,13 @@ public sealed partial class PlaywrightTools
             }).ConfigureAwait(false);
 
             _context.Page += ContextOnPage;
-            await _context.GrantAllPermissionsAsync().ConfigureAwait(false);
+            await _context.GrantPermissionsAsync(new[]
+            {
+                "clipboard-read",
+                "clipboard-write",
+                "geolocation",
+                "notifications"
+            }).ConfigureAwait(false);
 
             foreach (var page in _context.Pages.Where(p => !p.IsClosed))
             {


### PR DESCRIPTION
## Summary
- replace the unsupported GrantAllPermissionsAsync call with explicit permission grants on the browser context
- expose snapshot and tab descriptor models publicly so that public APIs can return them safely

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e29c0ab2c083298f3edb3e21a5fd63

## Sourcery 总结

授予明确的浏览器权限并公开内部模型

错误修复:
- 将不受支持的 GrantAllPermissionsAsync 调用替换为明确的 GrantPermissionsAsync，用于剪贴板、地理位置和通知

改进:
- 将 ConsoleMessageEntry、NetworkRequestEntry、SnapshotPayload 和 TabDescriptor 类型公开，以实现安全的 API 暴露

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Grant explicit browser permissions and expose internal models publicly

Bug Fixes:
- Replace unsupported GrantAllPermissionsAsync call with explicit GrantPermissionsAsync for clipboard, geolocation, and notifications

Enhancements:
- Make ConsoleMessageEntry, NetworkRequestEntry, SnapshotPayload, and TabDescriptor types public for safe API exposure

</details>