### PR TITLE
Fix Playwright tools accessibility and permissions

### DIFF
--- a/dotnet/BrowserModels.cs
+++ b/dotnet/BrowserModels.cs
@@ -6,7 +6,7 @@ using Microsoft.Playwright;
 
 namespace PlaywrightMcpServer;
 
-internal sealed record ConsoleMessageEntry
+public sealed record ConsoleMessageEntry
 {
     [JsonPropertyName("timestamp")] public DateTimeOffset Timestamp { get; init; }
     [JsonPropertyName("type")] public string Type { get; init; } = string.Empty;
@@ -14,7 +14,7 @@ internal sealed record ConsoleMessageEntry
     [JsonPropertyName("args")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string[]? Args { get; init; }
 }
 
-internal sealed class NetworkRequestEntry
+public sealed class NetworkRequestEntry
 {
     [JsonPropertyName("timestamp")] public DateTimeOffset Timestamp { get; init; }
     [JsonPropertyName("method")] public string Method { get; init; } = string.Empty;
@@ -34,7 +34,7 @@ internal sealed class NetworkRequestEntry
     };
 }
 
-internal sealed record SnapshotPayload
+public sealed record SnapshotPayload
 {
     [JsonPropertyName("timestamp")] public DateTimeOffset Timestamp { get; init; }
     [JsonPropertyName("url")] public string Url { get; init; } = string.Empty;
@@ -44,7 +44,7 @@ internal sealed record SnapshotPayload
     [JsonPropertyName("network")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public IReadOnlyList<NetworkRequestEntry>? Network { get; init; }
 }
 
-internal sealed record TabDescriptor
+public sealed record TabDescriptor
 {
     [JsonPropertyName("id")] public string Id { get; init; } = string.Empty;
     [JsonPropertyName("url")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? Url { get; init; }

--- a/dotnet/PlaywrightTools.cs
+++ b/dotnet/PlaywrightTools.cs
@@ -7,7 +7,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using ChatUiTest.Playwright.Helper;
 using Microsoft.Playwright;
 using ModelContextProtocol.Server;
 
@@ -87,7 +86,13 @@ public sealed partial class PlaywrightTools
             }).ConfigureAwait(false);
 
             _context.Page += ContextOnPage;
-            await _context.GrantAllPermissionsAsync().ConfigureAwait(false);
+            await _context.GrantPermissionsAsync(new[]
+            {
+                "clipboard-read",
+                "clipboard-write",
+                "geolocation",
+                "notifications"
+            }).ConfigureAwait(false);
 
             foreach (var page in _context.Pages.Where(p => !p.IsClosed))
             {

--- a/dotnet/TabManager.cs
+++ b/dotnet/TabManager.cs
@@ -154,7 +154,7 @@ internal sealed class TabState : IDisposable
     private readonly EventHandler<IRequest> _requestHandler;
     private readonly EventHandler<IResponse> _responseHandler;
     private readonly EventHandler<IRequest> _requestFailedHandler;
-    private readonly EventHandler _closeHandler;
+    private readonly EventHandler<IPage> _closeHandler;
 
     public TabState(IPage page, string id, DateTimeOffset createdAt, Action<TabState> onClosed)
     {


### PR DESCRIPTION
## Summary
- replace the unsupported GrantAllPermissionsAsync call with explicit permission grants on the browser context
- expose snapshot and tab descriptor models publicly so that public APIs can return them safely
- correct the page close event handler to use the proper generic signature for IPage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e29c0ab2c083298f3edb3e21a5fd63