### PR TITLE
Add .NET MCP response builder and helpers

### DIFF
--- a/dotnet/PlaywrightTools.cs
+++ b/dotnet/PlaywrightTools.cs
@@ -24,6 +24,7 @@ public sealed partial class PlaywrightTools
     private static readonly object Gate = new();
     private static readonly SnapshotManager SnapshotManager = new();
     private static readonly TabManager TabManager = new();
+    private static readonly ResponseConfiguration ResponseConfiguration = new();
     private static readonly Dictionary<string, ToolMetadata> ToolRegistry = new(StringComparer.OrdinalIgnoreCase);
 
     private static IPlaywright? _playwright;
@@ -63,6 +64,9 @@ public sealed partial class PlaywrightTools
         Path.GetFullPath("./traces");
 
     private static string Serialize(object value) => JsonSerializer.Serialize(value, JsonOptions);
+
+    private static Response CreateResponse(string toolName, IReadOnlyDictionary<string, object?> args, Action<string>? logger = null)
+        => new(new ResponseContext(TabManager, SnapshotManager, ResponseConfiguration), toolName, args, logger);
 
     private static async Task EnsureLaunchedAsync(CancellationToken cancellationToken)
     {

--- a/dotnet/Response.cs
+++ b/dotnet/Response.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PlaywrightMcpServer;
+
+public sealed class Response
+{
+    private readonly ResponseContext _context;
+    private readonly SecretRedactor _redactor;
+    private readonly List<string> _result = new();
+    private readonly List<string> _code = new();
+    private readonly List<ResponseImage> _images = new();
+
+    private SnapshotPayload? _snapshot;
+    private bool _includeSnapshot;
+    private bool _includeTabs;
+    private bool? _isError;
+
+    public Response(ResponseContext context, string toolName, IReadOnlyDictionary<string, object?> toolArgs, Action<string>? logger = null)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        ToolName = toolName ?? throw new ArgumentNullException(nameof(toolName));
+        ToolArgs = toolArgs ?? throw new ArgumentNullException(nameof(toolArgs));
+        Logger = logger;
+        _redactor = new SecretRedactor(context.Configuration.Secrets);
+    }
+
+    public string ToolName { get; }
+
+    public IReadOnlyDictionary<string, object?> ToolArgs { get; }
+
+    public Action<string>? Logger { get; }
+
+    public void AddResult(string result)
+    {
+        if (!string.IsNullOrEmpty(result))
+        {
+            _result.Add(result);
+        }
+    }
+
+    public void AddError(string error)
+    {
+        if (!string.IsNullOrEmpty(error))
+        {
+            _result.Add(error);
+        }
+
+        _isError = true;
+    }
+
+    public void AddCode(string code)
+    {
+        if (!string.IsNullOrEmpty(code))
+        {
+            _code.Add(code);
+        }
+    }
+
+    public void AddImage(string contentType, byte[] data)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(contentType);
+        ArgumentNullException.ThrowIfNull(data);
+        _images.Add(new ResponseImage(contentType, data));
+    }
+
+    public void SetIncludeSnapshot() => _includeSnapshot = true;
+
+    public void SetIncludeTabs() => _includeTabs = true;
+
+    public bool? IsError() => _isError;
+
+    public async Task FinishAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (_includeSnapshot && _context.CurrentTab is not null)
+        {
+            _snapshot = await _context.CaptureSnapshotAsync(_context.CurrentTab, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public SerializedResponse Serialize(ResponseSerializationOptions? options = null)
+    {
+        options ??= new ResponseSerializationOptions();
+
+        var sections = new List<string>();
+
+        if (_result.Count > 0)
+        {
+            sections.Add("### Result");
+            sections.Add(string.Join("\n", _result));
+            sections.Add(string.Empty);
+        }
+
+        if (_code.Count > 0)
+        {
+            sections.Add("### Ran Playwright code");
+            sections.Add("```js");
+            sections.Add(string.Join("\n", _code));
+            sections.Add("```");
+            sections.Add(string.Empty);
+        }
+
+        if (_includeSnapshot || _includeTabs)
+        {
+            sections.AddRange(RenderTabsMarkdown(_context.DescribeTabs(), _includeTabs));
+        }
+
+        if (_snapshot is not null)
+        {
+            sections.AddRange(SnapshotMarkdownBuilder.Build(_snapshot, options.OmitSnapshot));
+            sections.Add(string.Empty);
+        }
+
+        var text = string.Join("\n", sections);
+
+        var content = new List<IResponseContent>
+        {
+            new TextContent(text)
+        };
+
+        if (_context.Configuration.ImageResponses == ImageResponseMode.Include)
+        {
+            foreach (var image in _images)
+            {
+                var payload = options.OmitBlobs ? "<blob>" : Convert.ToBase64String(image.Data);
+                content.Add(new ImageContent(payload, image.ContentType));
+            }
+        }
+
+        _redactor.Redact(content);
+        return new SerializedResponse(content, _isError);
+    }
+
+    public void LogBegin()
+    {
+        Logger?.Invoke($"{ToolName}: begin {FormatArgs(ToolArgs)}");
+    }
+
+    public void LogEnd()
+    {
+        var summary = Serialize(new ResponseSerializationOptions { OmitSnapshot = true, OmitBlobs = true });
+        var text = summary.Content.OfType<TextContent>().FirstOrDefault()?.Text ?? string.Empty;
+        Logger?.Invoke($"{ToolName}: end {text}");
+    }
+
+    private static IReadOnlyList<string> RenderTabsMarkdown(IReadOnlyList<TabDescriptor> tabs, bool force)
+    {
+        if (tabs.Count == 1 && !force)
+        {
+            return Array.Empty<string>();
+        }
+
+        if (tabs.Count == 0)
+        {
+            return new[]
+            {
+                "### Open tabs",
+                "No open tabs. Use the \"browser_navigate\" tool to navigate to a page first.",
+                string.Empty
+            };
+        }
+
+        var lines = new List<string> { "### Open tabs" };
+        for (var i = 0; i < tabs.Count; i++)
+        {
+            var tab = tabs[i];
+            var current = tab.IsActive ? " (current)" : string.Empty;
+            var title = string.IsNullOrEmpty(tab.Title) ? "about:blank" : tab.Title;
+            var url = string.IsNullOrEmpty(tab.Url) ? "about:blank" : tab.Url;
+            lines.Add($"- {i}:{current} [{title}] ({url})");
+        }
+
+        lines.Add(string.Empty);
+        return lines;
+    }
+
+    private static string FormatArgs(IReadOnlyDictionary<string, object?> args)
+    {
+        if (args.Count == 0)
+        {
+            return "{}";
+        }
+
+        var parts = args
+            .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+            .Select(pair => $"{pair.Key}={pair.Value}");
+        return "{" + string.Join(", ", parts) + "}";
+    }
+
+    private sealed record ResponseImage(string ContentType, byte[] Data);
+}

--- a/dotnet/ResponseConfiguration.cs
+++ b/dotnet/ResponseConfiguration.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+
+namespace PlaywrightMcpServer;
+
+/// <summary>
+/// Configuration for response serialization behaviour.
+/// Mirrors the knobs available in the TypeScript implementation.
+/// </summary>
+public sealed class ResponseConfiguration
+{
+    /// <summary>
+    /// Determines whether image attachments should be emitted.
+    /// Defaults to <see cref="ImageResponseMode.Include"/> to match
+    /// the TypeScript runtime behaviour.
+    /// </summary>
+    public ImageResponseMode ImageResponses { get; init; } = ImageResponseMode.Include;
+
+    /// <summary>
+    /// Optional map of secrets that should be redacted from textual
+    /// responses. When present every occurrence of the value will be
+    /// replaced with <c>&lt;secret&gt;{name}&lt;/secret&gt;</c>.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Secrets { get; init; }
+        = null;
+}
+
+public enum ImageResponseMode
+{
+    Include,
+    Omit
+}

--- a/dotnet/ResponseContent.cs
+++ b/dotnet/ResponseContent.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Serialization;
+
+namespace PlaywrightMcpServer;
+
+public interface IResponseContent
+{
+    [JsonPropertyName("type")]
+    string Type { get; }
+}
+
+public sealed record TextContent(string Text) : IResponseContent
+{
+    [JsonPropertyName("type")]
+    public string Type => "text";
+
+    [JsonPropertyName("text")]
+    public string TextValue => Text;
+}
+
+public sealed record ImageContent(string Data, string MimeType) : IResponseContent
+{
+    [JsonPropertyName("type")]
+    public string Type => "image";
+
+    [JsonPropertyName("data")]
+    public string DataValue => Data;
+
+    [JsonPropertyName("mimeType")]
+    public string MimeTypeValue => MimeType;
+}
+
+public sealed record SerializedResponse(IReadOnlyList<IResponseContent> Content, bool? IsError);
+
+public sealed class ResponseSerializationOptions
+{
+    public bool OmitSnapshot { get; init; }
+
+    public bool OmitBlobs { get; init; }
+}

--- a/dotnet/ResponseContext.cs
+++ b/dotnet/ResponseContext.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PlaywrightMcpServer;
+
+public sealed class ResponseContext
+{
+    private readonly TabManager _tabManager;
+    private readonly SnapshotManager _snapshotManager;
+
+    public ResponseContext(TabManager tabManager, SnapshotManager snapshotManager, ResponseConfiguration configuration)
+    {
+        _tabManager = tabManager ?? throw new ArgumentNullException(nameof(tabManager));
+        _snapshotManager = snapshotManager ?? throw new ArgumentNullException(nameof(snapshotManager));
+        Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    }
+
+    public ResponseConfiguration Configuration { get; }
+
+    public IReadOnlyList<TabState> Tabs => _tabManager.Tabs;
+
+    public TabState? CurrentTab => _tabManager.ActiveTab;
+
+    public IReadOnlyList<TabDescriptor> DescribeTabs() => _tabManager.DescribeTabs();
+
+    public Task<SnapshotPayload> CaptureSnapshotAsync(TabState tab, CancellationToken cancellationToken)
+        => _snapshotManager.CaptureAsync(tab, cancellationToken);
+}

--- a/dotnet/ResponseParser.cs
+++ b/dotnet/ResponseParser.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PlaywrightMcpServer;
+
+public static class ResponseParser
+{
+    public static ParsedResponse? Parse(SerializedResponse response)
+    {
+        if (response.Content.Count == 0 || response.Content[0] is not TextContent text)
+        {
+            return null;
+        }
+
+        var sections = ParseSections(text.Text);
+        sections.TryGetValue("Result", out var result);
+        sections.TryGetValue("Ran Playwright code", out var code);
+        sections.TryGetValue("Open tabs", out var tabs);
+        sections.TryGetValue("Page state", out var pageState);
+        sections.TryGetValue("New console messages", out var console);
+        sections.TryGetValue("Modal state", out var modalState);
+        sections.TryGetValue("Downloads", out var downloads);
+
+        var codeBlock = code is null
+            ? null
+            : code
+                .Replace("```js\n", string.Empty)
+                .Replace("\n```", string.Empty);
+
+        return new ParsedResponse(
+            result,
+            codeBlock,
+            tabs,
+            pageState,
+            console,
+            modalState,
+            downloads,
+            response.IsError,
+            response.Content.Skip(1).ToArray());
+    }
+
+    private static Dictionary<string, string> ParseSections(string text)
+    {
+        var sections = new Dictionary<string, string>(StringComparer.Ordinal);
+        var lines = text.Split('\n');
+        string? currentName = null;
+        var buffer = new List<string>();
+
+        void Commit()
+        {
+            if (currentName is not null)
+            {
+                sections[currentName] = string.Join('\n', buffer).Trim();
+            }
+
+            buffer.Clear();
+        }
+
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine;
+            if (line.StartsWith("### ", StringComparison.Ordinal))
+            {
+                Commit();
+                currentName = line[4..].Trim();
+            }
+            else if (currentName is not null)
+            {
+                buffer.Add(line);
+            }
+        }
+
+        Commit();
+        return sections;
+    }
+}
+
+public sealed record ParsedResponse(
+    string? Result,
+    string? Code,
+    string? Tabs,
+    string? PageState,
+    string? ConsoleMessages,
+    string? ModalState,
+    string? Downloads,
+    bool? IsError,
+    IReadOnlyList<IResponseContent> Attachments);

--- a/dotnet/SecretRedactor.cs
+++ b/dotnet/SecretRedactor.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+
+namespace PlaywrightMcpServer;
+
+internal sealed class SecretRedactor
+{
+    private readonly IReadOnlyDictionary<string, string>? _secrets;
+
+    public SecretRedactor(IReadOnlyDictionary<string, string>? secrets)
+    {
+        _secrets = secrets;
+    }
+
+    public void Redact(IList<IResponseContent> content)
+    {
+        if (_secrets is null || _secrets.Count == 0)
+        {
+            return;
+        }
+
+        for (var i = 0; i < content.Count; i++)
+        {
+            if (content[i] is not TextContent textContent)
+            {
+                continue;
+            }
+
+            var value = textContent.Text;
+            foreach (var kvp in _secrets)
+            {
+                if (string.IsNullOrEmpty(kvp.Value))
+                {
+                    continue;
+                }
+
+                value = value.Replace(kvp.Value, $"<secret>{kvp.Key}</secret>");
+            }
+
+            content[i] = new TextContent(value);
+        }
+    }
+}

--- a/dotnet/SnapshotMarkdownBuilder.cs
+++ b/dotnet/SnapshotMarkdownBuilder.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace PlaywrightMcpServer;
+
+internal static class SnapshotMarkdownBuilder
+{
+    public static IReadOnlyList<string> Build(SnapshotPayload snapshot, bool omitSnapshot)
+    {
+        var lines = new List<string>();
+
+        if (snapshot.Console is { Count: > 0 })
+        {
+            lines.Add("### New console messages");
+            foreach (var entry in snapshot.Console)
+            {
+                lines.Add($"- {Trim(entry.Text, 100)}");
+            }
+
+            lines.Add(string.Empty);
+        }
+
+        if (snapshot.Network is { Count: > 0 })
+        {
+            lines.Add("### Network requests");
+            foreach (var entry in snapshot.Network)
+            {
+                var status = entry.Status?.ToString() ?? entry.Failure ?? "pending";
+                lines.Add($"- {entry.Method} {entry.Url} ({status})");
+            }
+
+            lines.Add(string.Empty);
+        }
+
+        lines.Add("### Page state");
+        lines.Add($"- Page URL: {snapshot.Url}");
+        lines.Add($"- Page Title: {snapshot.Title ?? string.Empty}");
+        lines.Add("- Page Snapshot:");
+        lines.Add("```json");
+        lines.Add(omitSnapshot ? "<snapshot>" : Format(snapshot.Aria));
+        lines.Add("```");
+
+        return lines;
+    }
+
+    private static string Format(JsonElement? element)
+    {
+        if (element is null)
+        {
+            return "null";
+        }
+
+        return JsonSerializer.Serialize(element.Value, new JsonSerializerOptions
+        {
+            WriteIndented = true
+        });
+    }
+
+    private static string Trim(string text, int maxLength)
+    {
+        if (string.IsNullOrEmpty(text) || text.Length <= maxLength)
+        {
+            return text;
+        }
+
+        return text.Substring(0, maxLength) + "...";
+    }
+}


### PR DESCRIPTION
## Summary
- add Response, context, and configuration types to mirror the TypeScript response pipeline
- provide markdown serialization, secret redaction, and parser utilities for .NET responses
- expose a helper on PlaywrightTools to construct responses with the shared infrastructure

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e497b9503483299306d3e07aba76b7