### PR TITLE
Adjust ResponseContext member accessibility

### DIFF
--- a/dotnet/ResponseContext.cs
+++ b/dotnet/ResponseContext.cs
@@ -10,7 +10,7 @@ public sealed class ResponseContext
     private readonly TabManager _tabManager;
     private readonly SnapshotManager _snapshotManager;
 
-    public ResponseContext(TabManager tabManager, SnapshotManager snapshotManager, ResponseConfiguration configuration)
+    internal ResponseContext(TabManager tabManager, SnapshotManager snapshotManager, ResponseConfiguration configuration)
     {
         _tabManager = tabManager ?? throw new ArgumentNullException(nameof(tabManager));
         _snapshotManager = snapshotManager ?? throw new ArgumentNullException(nameof(snapshotManager));
@@ -19,12 +19,12 @@ public sealed class ResponseContext
 
     public ResponseConfiguration Configuration { get; }
 
-    public IReadOnlyList<TabState> Tabs => _tabManager.Tabs;
+    internal IReadOnlyList<TabState> Tabs => _tabManager.Tabs;
 
-    public TabState? CurrentTab => _tabManager.ActiveTab;
+    internal TabState? CurrentTab => _tabManager.ActiveTab;
 
     public IReadOnlyList<TabDescriptor> DescribeTabs() => _tabManager.DescribeTabs();
 
-    public Task<SnapshotPayload> CaptureSnapshotAsync(TabState tab, CancellationToken cancellationToken)
+    internal Task<SnapshotPayload> CaptureSnapshotAsync(TabState tab, CancellationToken cancellationToken)
         => _snapshotManager.CaptureAsync(tab, cancellationToken);
 }


### PR DESCRIPTION
## Summary
- align ResponseContext's constructor and TabState-related members with internal accessibility to resolve compiler warnings about inconsistent visibility

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e4a242e56c832984b2671e4337a92c

## Sourcery 总结

改进：
- 将 `ResponseContext` 构造函数、`Tabs`、`CurrentTab` 和 `CaptureSnapshotAsync` 设为 internal，以统一可见性并抑制不一致可访问性警告

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Make ResponseContext constructor, Tabs, CurrentTab, and CaptureSnapshotAsync internal to unify visibility and suppress inconsistent-accessibility warnings

</details>