### PR TITLE
Integrate response helper into navigation actions

### DIFF
--- a/dotnet/ResponseContent.cs
+++ b/dotnet/ResponseContent.cs
@@ -29,7 +29,9 @@ public sealed record ImageContent(string Data, string MimeType) : IResponseConte
     public string MimeTypeValue => MimeType;
 }
 
-public sealed record SerializedResponse(IReadOnlyList<IResponseContent> Content, bool? IsError);
+public sealed record SerializedResponse(
+    [property: JsonPropertyName("content")] IReadOnlyList<IResponseContent> Content,
+    [property: JsonPropertyName("isError")] bool? IsError);
 
 public sealed class ResponseSerializationOptions
 {


### PR DESCRIPTION
## Summary
- add a shared helper to execute MCP tools using the Response serializer
- migrate the navigation tools to populate results, code snippets, and snapshot flags through Response
- ensure serialized responses emit camelCase property names for protocol compatibility

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68e4b002255083298af0ad08c83e5b2e