### PR TITLE
Implement browser_fill_form tool logic

### DIFF
--- a/dotnet/PlaywrightTools.Actions.Form.cs
+++ b/dotnet/PlaywrightTools.Actions.Form.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Playwright;
 using ModelContextProtocol.Server;
 
 namespace PlaywrightMcpServer;
@@ -18,14 +19,106 @@ public sealed partial class PlaywrightTools
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        // TODO: Implement the browser_fill_form tool.
-        // The implementation should:
-        // 1. Validate the request payload matches the schema used by the TypeScript tool (fields array of objects).
-        // 2. Resolve each field's locator using the snapshot reference.
-        // 3. Dispatch the proper Playwright action based on the field type (textbox, checkbox, radio, combobox, slider).
-        // 4. Return a serialized response mirroring the TypeScript backend (success flags, snapshot, tab list, etc.).
-        await Task.CompletedTask;
-        throw new NotImplementedException();
+        ArgumentNullException.ThrowIfNull(request);
+
+        var args = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["fields"] = request.Fields?.Count ?? 0
+        };
+
+        return await ExecuteWithResponseAsync(
+            "browser_fill_form",
+            args,
+            async (response, token) =>
+            {
+                if (request.Fields is null || request.Fields.Count == 0)
+                {
+                    response.AddResult("No form fields were provided.");
+                    response.SetIncludeTabs();
+                    return;
+                }
+
+                var tab = await GetActiveTabAsync(token).ConfigureAwait(false);
+                var page = tab.Page;
+                var updates = new List<string>();
+
+                foreach (var field in request.Fields)
+                {
+                    token.ThrowIfCancellationRequested();
+
+                    if (field is null)
+                    {
+                        continue;
+                    }
+
+                    if (string.IsNullOrWhiteSpace(field.Reference))
+                    {
+                        throw new ArgumentException($"Field \"{field.Name}\" is missing the required \"ref\" value.");
+                    }
+
+                    var normalizedType = NormalizeFieldType(field.Type);
+                    if (normalizedType == BrowserFillFormFieldType.Unknown)
+                    {
+                        throw new ArgumentException($"Unsupported field type '{field.Type}'.");
+                    }
+
+                    var locator = page.Locator($"aria-ref={field.Reference}");
+                    var locatorSource = $"await page.locator({QuoteJsString($"aria-ref={field.Reference}")})";
+
+                    try
+                    {
+                        switch (normalizedType)
+                        {
+                            case BrowserFillFormFieldType.Textbox:
+                            case BrowserFillFormFieldType.Slider:
+                                {
+                                    var secret = LookupSecret(field.Value);
+                                    await locator.FillAsync(secret.Value).ConfigureAwait(false);
+                                    response.AddCode($"{locatorSource}.fill({secret.Code});");
+                                    updates.Add($"- Filled {DescribeField(field)}.");
+                                    break;
+                                }
+
+                            case BrowserFillFormFieldType.Checkbox:
+                            case BrowserFillFormFieldType.Radio:
+                                {
+                                    var isChecked = ParseBoolean(field.Value, field.Name);
+                                    await locator.SetCheckedAsync(isChecked).ConfigureAwait(false);
+                                    var literal = isChecked ? "true" : "false";
+                                    response.AddCode($"{locatorSource}.setChecked({literal});");
+                                    updates.Add($"- Set {DescribeField(field)} to {(isChecked ? "checked" : "unchecked")}.");
+                                    break;
+                                }
+
+                            case BrowserFillFormFieldType.Combobox:
+                                {
+                                    var optionLabel = field.Value ?? string.Empty;
+                                    await locator.SelectOptionAsync(new[] { new SelectOptionValue { Label = optionLabel } }).ConfigureAwait(false);
+                                    response.AddCode($"{locatorSource}.selectOption({QuoteJsString(optionLabel)});");
+                                    updates.Add($"- Selected \"{optionLabel}\" for {DescribeField(field)}.");
+                                    break;
+                                }
+                        }
+                    }
+                    catch (PlaywrightException ex)
+                    {
+                        throw CreateLocatorException(field, ex);
+                    }
+                }
+
+                if (updates.Count > 0)
+                {
+                    response.AddResult("Updated form fields:\n" + string.Join("\n", updates));
+                }
+                else
+                {
+                    response.AddResult("No form fields were updated.");
+                }
+
+                response.SetIncludeSnapshot();
+                response.SetIncludeTabs();
+            },
+            cancellationToken).ConfigureAwait(false);
     }
 
     [Description("Payload describing all fields to populate in the form.")]
@@ -54,5 +147,88 @@ public sealed partial class PlaywrightTools
         [Description("Value to fill in the field. If the field is a checkbox, the value should be `true` or `false`. If the field is a combobox, the value should be the text of the option.")]
         [JsonPropertyName("value")]
         public string? Value { get; init; }
+    }
+
+    private enum BrowserFillFormFieldType
+    {
+        Unknown,
+        Textbox,
+        Checkbox,
+        Radio,
+        Combobox,
+        Slider
+    }
+
+    private static BrowserFillFormFieldType NormalizeFieldType(string? type)
+    {
+        if (string.IsNullOrWhiteSpace(type))
+        {
+            return BrowserFillFormFieldType.Unknown;
+        }
+
+        return type.Trim().ToLowerInvariant() switch
+        {
+            "textbox" => BrowserFillFormFieldType.Textbox,
+            "checkbox" => BrowserFillFormFieldType.Checkbox,
+            "radio" => BrowserFillFormFieldType.Radio,
+            "combobox" => BrowserFillFormFieldType.Combobox,
+            "slider" => BrowserFillFormFieldType.Slider,
+            _ => BrowserFillFormFieldType.Unknown
+        };
+    }
+
+    private static (string Value, string Code) LookupSecret(string? candidate)
+    {
+        var normalized = candidate ?? string.Empty;
+
+        if (ResponseConfiguration.Secrets is { } secrets && secrets.TryGetValue(normalized, out var secretValue) && !string.IsNullOrEmpty(secretValue))
+        {
+            return (secretValue, $"process.env[{QuoteJsString(normalized)}]");
+        }
+
+        return (normalized, QuoteJsString(normalized));
+    }
+
+    private static bool ParseBoolean(string? value, string fieldName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException($"Field \"{fieldName}\" requires a boolean value of 'true' or 'false'.");
+        }
+
+        if (bool.TryParse(value, out var result))
+        {
+            return result;
+        }
+
+        throw new ArgumentException($"Value '{value}' for field \"{fieldName}\" is not a valid boolean literal. Use 'true' or 'false'.");
+    }
+
+    private static string DescribeField(BrowserFillFormField field)
+    {
+        var name = string.IsNullOrWhiteSpace(field.Name) ? "field" : field.Name;
+        var type = string.IsNullOrWhiteSpace(field.Type) ? "unknown" : field.Type;
+        return $"{name} ({type})";
+    }
+
+    private static string QuoteJsString(string? value)
+    {
+        value ??= string.Empty;
+
+        return "'" + value
+            .Replace("\\", "\\\\")
+            .Replace("\r", "\\r")
+            .Replace("\n", "\\n")
+            .Replace("\t", "\\t")
+            .Replace("'", "\\'")
+            + "'";
+    }
+
+    private static Exception CreateLocatorException(BrowserFillFormField field, PlaywrightException inner)
+    {
+        var name = string.IsNullOrWhiteSpace(field.Name) ? field.Reference : field.Name;
+        return new InvalidOperationException(
+            $"Unable to locate element '{name}' with ref '{field.Reference}'. Capture a new snapshot and try again.",
+            inner);
     }
 }


### PR DESCRIPTION
## Summary
- implement the C# browser_fill_form tool to locate fields by reference and perform the proper Playwright action
- add secret-aware value handling, boolean parsing, and result reporting with snapshot/tab refresh

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e4cf0f82788329902911ac4f8ee9ae