### PR TITLE
Align browser snapshot tool with response pipeline

### DIFF
--- a/dotnet/PlaywrightTools.Actions.Snapshot.cs
+++ b/dotnet/PlaywrightTools.Actions.Snapshot.cs
@@ -1,18 +1,12 @@
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Playwright;
 using ModelContextProtocol.Server;
 
 namespace PlaywrightMcpServer;
 
-/*
- * NOTE: TypeScript version of `browser_snapshot` only toggles `response.setIncludeSnapshot()` and defers
- * snapshot collection to the response pipeline (`Response.finish()`). The .NET MCP server lacks that
- * centralized injection step, so we capture and serialize the accessibility tree immediately. This keeps
- * the architecture simpler, surfaces page state to the LLM right away, and improves observability during
- * integration and debugging.
- */
 public sealed partial class PlaywrightTools
 {
     [McpServerTool(Name = "browser_snapshot")]
@@ -20,34 +14,16 @@ public sealed partial class PlaywrightTools
     public static async Task<string> BrowserSnapshotAsync(
         CancellationToken cancellationToken = default)
     {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var tab = await GetActiveTabAsync(cancellationToken).ConfigureAwait(false);
-        var page = tab.Page;
-
-        object? accessibilitySnapshot = null;
-        try
-        {
-            accessibilitySnapshot = await page.Accessibility.SnapshotAsync(new AccessibilitySnapshotOptions
+        return await ExecuteWithResponseAsync(
+            "browser_snapshot",
+            new Dictionary<string, object?>(StringComparer.Ordinal),
+            async (response, token) =>
             {
-                InterestingOnly = false
-            }).ConfigureAwait(false);
-        }
-        catch (PlaywrightException)
-        {
-            // Align with SnapshotManager: swallow accessibility errors so the tool still succeeds.
-        }
-
-        var title = await page.TitleAsync().ConfigureAwait(false);
-
-        var payload = new
-        {
-            includeSnapshot = true,
-            url = page.Url,
-            title,
-            snapshot = accessibilitySnapshot
-        };
-
-        return Serialize(payload);
+                // Ensure there is an active tab so the response pipeline can capture a snapshot
+                // and attach the appropriate element references (`ref`).
+                await GetActiveTabAsync(token).ConfigureAwait(false);
+                response.SetIncludeSnapshot();
+            },
+            cancellationToken).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
## Summary
- update the C# browser_snapshot tool to follow the shared response pipeline so snapshots include generated element refs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e528a3cdbc8329bb93591d069a0ee6