### PR TITLE
Implement tab snapshot capture helper

### DIFF
--- a/dotnet/PlaywrightTools.cs
+++ b/dotnet/PlaywrightTools.cs
@@ -23,7 +23,7 @@ public sealed partial class PlaywrightTools
 
     private static readonly object Gate = new();
     private static readonly SnapshotManager SnapshotManager = new();
-    private static readonly TabManager TabManager = new();
+    private static readonly TabManager TabManager = new(SnapshotManager);
     private static readonly ResponseConfiguration ResponseConfiguration = new();
     private static readonly Dictionary<string, ToolMetadata> ToolRegistry = new(StringComparer.OrdinalIgnoreCase);
 
@@ -97,7 +97,7 @@ public sealed partial class PlaywrightTools
     }
 
     private static Response CreateResponse(string toolName, IReadOnlyDictionary<string, object?> args, Action<string>? logger = null)
-        => new(new ResponseContext(TabManager, SnapshotManager, ResponseConfiguration), toolName, args, logger);
+        => new(new ResponseContext(TabManager, ResponseConfiguration), toolName, args, logger);
 
     private static async Task EnsureLaunchedAsync(CancellationToken cancellationToken)
     {
@@ -228,7 +228,7 @@ public sealed partial class PlaywrightTools
     public static async Task<SnapshotPayload> GetAriaSnapshotAsync(CancellationToken cancellationToken = default)
     {
         var tab = await GetActiveTabAsync(cancellationToken).ConfigureAwait(false);
-        return await SnapshotManager.CaptureAsync(tab, cancellationToken).ConfigureAwait(false);
+        return await tab.CaptureSnapshotAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public static IReadOnlyList<TabDescriptor> DescribeTabs()

--- a/dotnet/ResponseContext.cs
+++ b/dotnet/ResponseContext.cs
@@ -8,12 +8,10 @@ namespace PlaywrightMcpServer;
 public sealed class ResponseContext
 {
     private readonly TabManager _tabManager;
-    private readonly SnapshotManager _snapshotManager;
 
-    internal ResponseContext(TabManager tabManager, SnapshotManager snapshotManager, ResponseConfiguration configuration)
+    internal ResponseContext(TabManager tabManager, ResponseConfiguration configuration)
     {
         _tabManager = tabManager ?? throw new ArgumentNullException(nameof(tabManager));
-        _snapshotManager = snapshotManager ?? throw new ArgumentNullException(nameof(snapshotManager));
         Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
     }
 
@@ -26,5 +24,5 @@ public sealed class ResponseContext
     public IReadOnlyList<TabDescriptor> DescribeTabs() => _tabManager.DescribeTabs();
 
     internal Task<SnapshotPayload> CaptureSnapshotAsync(TabState tab, CancellationToken cancellationToken)
-        => _snapshotManager.CaptureAsync(tab, cancellationToken);
+        => tab.CaptureSnapshotAsync(cancellationToken);
 }


### PR DESCRIPTION
## Summary
- inject SnapshotManager into TabManager so each tab can capture snapshots directly
- add TabState.CaptureSnapshotAsync to call SnapshotManager with a minimal Playwright fallback
- update ResponseContext and PlaywrightTools to use the new helper when requesting snapshots

## Testing
- not run (no .NET project file provided)


------
https://chatgpt.com/codex/tasks/task_e_68e54334ea8c832992787b8b97c95a38