### PR TITLE
Track modal state metadata during snapshot capture

### DIFF
--- a/dotnet/BrowserModels.cs
+++ b/dotnet/BrowserModels.cs
@@ -6,6 +6,15 @@ using Microsoft.Playwright;
 
 namespace PlaywrightMcpServer;
 
+public sealed record ModalStateEntry
+{
+    [JsonPropertyName("type")] public string Type { get; init; } = string.Empty;
+    [JsonPropertyName("description")] public string Description { get; init; } = string.Empty;
+    [JsonPropertyName("clearedBy")] public string ClearedBy { get; init; } = string.Empty;
+    [JsonIgnore] public IDialog? Dialog { get; init; }
+    [JsonIgnore] public IFileChooser? FileChooser { get; init; }
+}
+
 public sealed record ConsoleMessageEntry
 {
     [JsonPropertyName("timestamp")] public DateTimeOffset Timestamp { get; init; }
@@ -42,6 +51,7 @@ public sealed record SnapshotPayload
     [JsonPropertyName("aria")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public JsonElement? Aria { get; init; }
     [JsonPropertyName("console")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public IReadOnlyList<ConsoleMessageEntry>? Console { get; init; }
     [JsonPropertyName("network")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public IReadOnlyList<NetworkRequestEntry>? Network { get; init; }
+    [JsonPropertyName("modalStates")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public IReadOnlyList<ModalStateEntry>? ModalStates { get; init; }
 }
 
 public sealed record TabDescriptor

--- a/dotnet/ResponseContext.cs
+++ b/dotnet/ResponseContext.cs
@@ -26,5 +26,5 @@ public sealed class ResponseContext
     public IReadOnlyList<TabDescriptor> DescribeTabs() => _tabManager.DescribeTabs();
 
     internal Task<SnapshotPayload> CaptureSnapshotAsync(TabState tab, CancellationToken cancellationToken)
-        => _snapshotManager.CaptureAsync(tab, cancellationToken);
+        => tab.CaptureSnapshotAsync(_snapshotManager, cancellationToken);
 }

--- a/dotnet/SnapshotManager.cs
+++ b/dotnet/SnapshotManager.cs
@@ -43,7 +43,8 @@ internal sealed class SnapshotManager
             Title = title,
             Aria = aria,
             Console = console,
-            Network = network
+            Network = network,
+            ModalStates = tab.GetModalStatesSnapshot()
         };
 
         tab.UpdateMetadata(url, title, snapshot);

--- a/dotnet/SnapshotMarkdownBuilder.cs
+++ b/dotnet/SnapshotMarkdownBuilder.cs
@@ -10,6 +10,24 @@ internal static class SnapshotMarkdownBuilder
     {
         var lines = new List<string>();
 
+        if (snapshot.ModalStates is { } modalStates)
+        {
+            lines.Add("### Modal state");
+            if (modalStates.Count == 0)
+            {
+                lines.Add("- There is no modal state present");
+            }
+            else
+            {
+                foreach (var state in modalStates)
+                {
+                    lines.Add($"- [{state.Description}]: can be handled by the \"{state.ClearedBy}\" tool");
+                }
+            }
+
+            lines.Add(string.Empty);
+        }
+
         if (snapshot.Console is { Count: > 0 })
         {
             lines.Add("### New console messages");


### PR DESCRIPTION
## Summary
- add a `ModalStateEntry` model and surface modal-state lists on `SnapshotPayload`
- track dialog and file-chooser modals in `TabState`, race snapshot capture against modal events, and fall back to modal metadata when blocked
- render modal state information in snapshot markdown and refresh the developer notes

## Testing
- not run (no automated test suite provided)

------
https://chatgpt.com/codex/tasks/task_e_68e5b1669ee48329ad9196b1c8602cd3

## Sourcery 总结

通过在 TabState 中捕获模态元数据，将其集成到快照负载中，并在快照 Markdown 中渲染，从而启用对话框和文件选择器模态状态的回放。

新功能：
- 在快照捕获期间跟踪和记录对话框和文件选择器模态
- 引入 ModalStateEntry 模型并将模态状态列表附加到 SnapshotPayload

改进：
- 实现 RaceAgainstModalStatesAsync 以在模态事件发生时进行快照捕获竞争，并带有回退机制
- 在 Markdown 输出中包含模态状态元数据并更新文档示例

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable playback of dialog and file chooser modal states by capturing modal metadata in TabState, integrating it into snapshot payloads, and rendering it in snapshot markdown

New Features:
- Track and record dialog and file chooser modals during snapshot capture
- Introduce ModalStateEntry model and attach modal state lists to SnapshotPayload

Enhancements:
- Implement RaceAgainstModalStatesAsync to race snapshot capture against modal events with fallback
- Include modal state metadata in Markdown output and update documentation example

</details>