### PR TITLE
Handle download-triggered navigations

### DIFF
--- a/dotnet/PlaywrightMcpServer.Tests/NavigateIntegrationTests.cs
+++ b/dotnet/PlaywrightMcpServer.Tests/NavigateIntegrationTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using Moq;
+using Xunit;
+
+namespace PlaywrightMcpServer.Tests;
+
+public class NavigateIntegrationTests
+{
+    [Fact]
+    public async Task NavigateAsyncRecordsDownloadInResponse()
+    {
+        var url = "https://example.test/download";
+        var tabManager = new TabManager();
+        var pageMock = new Mock<IPage>();
+        var downloadMock = new Mock<IDownload>();
+        var saveCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        pageMock.SetupGet(p => p.Url).Returns(url);
+        pageMock.Setup(p => p.GotoAsync(It.IsAny<string>(), It.IsAny<PageGotoOptions?>()))
+            .Returns<string, PageGotoOptions?>((requestedUrl, _) =>
+            {
+                Assert.Equal(url, requestedUrl);
+                _ = Task.Run(async () =>
+                {
+                    await Task.Delay(50).ConfigureAwait(false);
+                    pageMock.Raise(m => m.Download += null!, downloadMock.Object);
+                });
+
+                return Task.FromException<IResponse?>(new PlaywrightException("net::ERR_ABORTED"));
+            });
+        pageMock.Setup(p => p.WaitForLoadStateAsync(It.IsAny<LoadState>(), It.IsAny<PageWaitForLoadStateOptions?>()))
+            .Returns(Task.CompletedTask);
+        pageMock.Setup(p => p.TitleAsync()).ReturnsAsync("Download ready");
+
+        downloadMock.SetupGet(d => d.SuggestedFilename).Returns("report.pdf");
+        downloadMock.Setup(d => d.SaveAsAsync(It.IsAny<string>(), It.IsAny<DownloadSaveAsOptions?>()))
+            .Returns<string, DownloadSaveAsOptions?>((_, _) =>
+            {
+                saveCompletion.TrySetResult(true);
+                return Task.CompletedTask;
+            });
+
+        var tab = tabManager.Register(pageMock.Object);
+
+        var navigationResponse = await tab.NavigateAsync(url, new PageGotoOptions
+        {
+            WaitUntil = WaitUntilState.NetworkIdle
+        }, CancellationToken.None).ConfigureAwait(false);
+
+        Assert.Null(navigationResponse);
+        await saveCompletion.Task.WaitAsync(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+
+        var downloads = tab.GetDownloadsSnapshot();
+        Assert.Single(downloads);
+        Assert.Equal("report.pdf", downloads[0].SuggestedFileName);
+        Assert.True(downloads[0].Finished);
+
+        var snapshotManager = new SnapshotManager();
+        var snapshot = await tab.CaptureSnapshotAsync(snapshotManager, CancellationToken.None).ConfigureAwait(false);
+        Assert.Single(snapshot.Downloads);
+        Assert.Equal("report.pdf", snapshot.Downloads[0].SuggestedFileName);
+
+        var responseContext = new ResponseContext(tabManager, snapshotManager, new ResponseConfiguration());
+        var response = new Response(responseContext, "browser_navigate", new Dictionary<string, object?>());
+        response.AddResult($"Navigated to {url}");
+        response.SetIncludeSnapshot();
+        response.SetIncludeTabs();
+
+        await response.FinishAsync(CancellationToken.None).ConfigureAwait(false);
+        var serialized = response.Serialize();
+        var textContent = Assert.IsType<TextContent>(Assert.Single(serialized.Content));
+        Assert.Contains("Downloaded file report.pdf", textContent.Text, StringComparison.Ordinal);
+    }
+}

--- a/dotnet/PlaywrightMcpServer.Tests/PlaywrightMcpServer.Tests.csproj
+++ b/dotnet/PlaywrightMcpServer.Tests/PlaywrightMcpServer.Tests.csproj
@@ -8,9 +8,18 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.41.2" />
+    <PackageReference Include="Moq" Version="4.20.70" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="../BrowserModels.cs" />
+    <Compile Include="../Response.cs" />
+    <Compile Include="../ResponseConfiguration.cs" />
+    <Compile Include="../ResponseContent.cs" />
+    <Compile Include="../ResponseContext.cs" />
+    <Compile Include="../SecretRedactor.cs" />
     <Compile Include="../SnapshotMarkdownBuilder.cs" />
+    <Compile Include="../SnapshotManager.cs" />
+    <Compile Include="../TabManager.cs" />
   </ItemGroup>
 </Project>

--- a/dotnet/PlaywrightMcpServer.Tests/PlaywrightTools.TestStubs.cs
+++ b/dotnet/PlaywrightMcpServer.Tests/PlaywrightTools.TestStubs.cs
@@ -1,0 +1,9 @@
+using System.IO;
+
+namespace PlaywrightMcpServer;
+
+public sealed partial class PlaywrightTools
+{
+    internal static string ResolveDownloadOutputPath(string outputPath)
+        => Path.GetFullPath(outputPath);
+}

--- a/dotnet/PlaywrightTools.Actions.Navigate.cs
+++ b/dotnet/PlaywrightTools.Actions.Navigate.cs
@@ -33,10 +33,10 @@ public sealed partial class PlaywrightTools
             async (response, token) =>
             {
                 var tab = await GetActiveTabAsync(token).ConfigureAwait(false);
-                var navigationResponse = await tab.Page.GotoAsync(normalizedUrl, new PageGotoOptions
+                var navigationResponse = await tab.NavigateAsync(normalizedUrl, new PageGotoOptions
                 {
                     WaitUntil = WaitUntilState.NetworkIdle
-                }).ConfigureAwait(false);
+                }, token).ConfigureAwait(false);
 
                 var resultLines = new List<string>
                 {

--- a/dotnet/PlaywrightTools.Actions.Relaunch.cs
+++ b/dotnet/PlaywrightTools.Actions.Relaunch.cs
@@ -36,10 +36,10 @@ public sealed partial class PlaywrightTools
             var first = restorePlan[0];
             if (!string.IsNullOrWhiteSpace(first.Url))
             {
-                await activeTab.Page.GotoAsync(first.Url, new PageGotoOptions
+                await activeTab.NavigateAsync(first.Url, new PageGotoOptions
                 {
                     WaitUntil = WaitUntilState.NetworkIdle
-                }).ConfigureAwait(false);
+                }, cancellationToken).ConfigureAwait(false);
                 initialSnapshot = await SnapshotManager.CaptureAsync(activeTab, cancellationToken).ConfigureAwait(false);
             }
 
@@ -51,10 +51,10 @@ public sealed partial class PlaywrightTools
                 var tab = TabManager.Register(page, makeActive: false);
                 if (!string.IsNullOrWhiteSpace(entry.Url))
                 {
-                    await page.GotoAsync(entry.Url, new PageGotoOptions
+                    await tab.NavigateAsync(entry.Url, new PageGotoOptions
                     {
                         WaitUntil = WaitUntilState.NetworkIdle
-                    }).ConfigureAwait(false);
+                    }, cancellationToken).ConfigureAwait(false);
                     await SnapshotManager.CaptureAsync(tab, cancellationToken).ConfigureAwait(false);
                 }
             }


### PR DESCRIPTION
## Summary
- add a TabState.NavigateAsync helper that resets tracked activity, watches for download-only navigations, and limits the post-load wait
- update navigation entry points to route through the helper so downloads resolve cleanly before taking snapshots
- expand the test project with the necessary dependencies and add an integration test that exercises a download-triggering navigation

## Testing
- `dotnet test dotnet/PlaywrightMcpServer.Tests/PlaywrightMcpServer.Tests.csproj` *(fails: `dotnet` command unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5befa351c83299f0d78923cc29975

## Sourcery 总结

在 `TabState` 中引入一个新的 `NavigateAsync` 方法，以清晰地处理由下载触发的导航，重构现有的导航调用以使用它，并添加一个集成测试来验证下载行为。

新功能：
- 添加 `TabState.NavigateAsync` 辅助方法，用于重置活动、监测仅限下载的导航并限制加载后的等待时间

改进：
- 更新 actions 中的导航入口点，以使用 `NavigateAsync` 进行一致的下载处理
- 在每次导航前清除控制台和网络活动队列

测试：
- 添加 `NavigateIntegrationTests` 以验证由下载触发的导航和快照行为
- 在 `PlaywrightTools` 中引入测试存根，用于解析下载输出路径

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a new NavigateAsync method in TabState to handle download-triggered navigations cleanly, refactor existing navigation calls to use it, and add an integration test to verify download behavior

New Features:
- Add TabState.NavigateAsync helper to reset activity, watch for download-only navigations, and limit post-load wait

Enhancements:
- Update navigation entry points in actions to use NavigateAsync for consistent download handling
- Clear console and network activity queues before each navigation

Tests:
- Add NavigateIntegrationTests to validate download-triggered navigations and snapshot behavior
- Introduce test stub in PlaywrightTools for resolving download output paths

</details>