### PR TITLE
Fix WaitForDownloadSignalAsync cancellation return value

### DIFF
--- a/dotnet/TabManager.cs
+++ b/dotnet/TabManager.cs
@@ -494,7 +494,7 @@ internal sealed class TabState : IDisposable
             if (cancellationToken.IsCancellationRequested)
             {
                 tcs.TrySetResult(false);
-                return tcs.Task;
+                return false;
             }
 
             _downloadWaiters.Add(tcs);


### PR DESCRIPTION
## Summary
- ensure WaitForDownloadSignalAsync returns a boolean value when cancellation is requested instead of the task itself

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5c4b16d748329ad7aec56eac9b6e0