### PR TITLE
Add Playwright tab completion wait helper and tests

### DIFF
--- a/dotnet/PlaywrightMcpServer.Tests/TabStateWaitForCompletionTests.cs
+++ b/dotnet/PlaywrightMcpServer.Tests/TabStateWaitForCompletionTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using Moq;
+using Xunit;
+
+namespace PlaywrightMcpServer.Tests;
+
+public class TabStateWaitForCompletionTests
+{
+    [Fact]
+    public async Task WaitForCompletionAsync_WaitsForOutstandingRequests()
+    {
+        var tabManager = new TabManager();
+        var pageMock = new Mock<IPage>();
+        pageMock.SetupGet(p => p.Url).Returns("https://example.test");
+
+        var delayCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        pageMock.Setup(p => p.WaitForTimeoutAsync(It.IsAny<float>()))
+            .Returns<float>(_ => delayCompletion.Task);
+
+        var tab = tabManager.Register(pageMock.Object);
+
+        var requestMock = new Mock<IRequest>();
+        var responseMock = new Mock<IResponse>();
+        responseMock.SetupGet(r => r.Request).Returns(requestMock.Object);
+
+        var responseCompletion = new TaskCompletionSource<IResponse?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        requestMock.Setup(r => r.ResponseAsync()).Returns(responseCompletion.Task);
+
+        var waitTask = tab.WaitForCompletionAsync(async ct =>
+        {
+            pageMock.Raise(m => m.Request += null!, requestMock.Object);
+            await Task.CompletedTask;
+        }, CancellationToken.None);
+
+        await Task.Delay(50).ConfigureAwait(false);
+        Assert.False(waitTask.IsCompleted);
+
+        pageMock.Raise(m => m.Response += null!, responseMock.Object);
+        responseCompletion.TrySetResult(responseMock.Object);
+
+        await Task.Delay(50).ConfigureAwait(false);
+        Assert.False(waitTask.IsCompleted);
+
+        delayCompletion.TrySetResult(true);
+
+        await waitTask.WaitAsync(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+        pageMock.Verify(p => p.WaitForTimeoutAsync(1000), Times.Once);
+    }
+
+    [Fact]
+    public async Task WaitForCompletionAsync_UnblocksWhenModalAppears()
+    {
+        var tabManager = new TabManager();
+        var pageMock = new Mock<IPage>();
+        pageMock.SetupGet(p => p.Url).Returns("https://example.test");
+        pageMock.Setup(p => p.WaitForTimeoutAsync(It.IsAny<float>())).Returns(Task.CompletedTask);
+
+        var tab = tabManager.Register(pageMock.Object);
+        var blocker = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var waitTask = tab.WaitForCompletionAsync(_ => blocker.Task, CancellationToken.None);
+
+        await Task.Delay(50).ConfigureAwait(false);
+        Assert.False(waitTask.IsCompleted);
+
+        var dialogMock = new Mock<IDialog>();
+        dialogMock.SetupGet(d => d.Type).Returns("alert");
+        dialogMock.SetupGet(d => d.Message).Returns("Blocking dialog");
+
+        pageMock.Raise(m => m.Dialog += null!, dialogMock.Object);
+
+        await waitTask.WaitAsync(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+
+        blocker.TrySetResult();
+    }
+
+    [Fact]
+    public async Task WaitForCompletionAsync_WaitsForPostActionDelay()
+    {
+        var tabManager = new TabManager();
+        var pageMock = new Mock<IPage>();
+        pageMock.SetupGet(p => p.Url).Returns("https://example.test");
+
+        var delayCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        pageMock.Setup(p => p.WaitForTimeoutAsync(It.IsAny<float>()))
+            .Returns<float>(_ => delayCompletion.Task);
+
+        var tab = tabManager.Register(pageMock.Object);
+
+        var waitTask = tab.WaitForCompletionAsync(_ => Task.CompletedTask, CancellationToken.None);
+
+        await Task.Delay(50).ConfigureAwait(false);
+        Assert.False(waitTask.IsCompleted);
+
+        delayCompletion.TrySetResult(true);
+
+        await waitTask.WaitAsync(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+        pageMock.Verify(p => p.WaitForTimeoutAsync(1000), Times.Once);
+    }
+}

--- a/dotnet/PlaywrightTools.Actions.Navigate.cs
+++ b/dotnet/PlaywrightTools.Actions.Navigate.cs
@@ -67,10 +67,15 @@ public sealed partial class PlaywrightTools
             async (response, token) =>
             {
                 var tab = await GetActiveTabAsync(token).ConfigureAwait(false);
-                var navigationResponse = await tab.Page.GoBackAsync(new PageGoBackOptions
+                IResponse? navigationResponse = null;
+
+                await tab.WaitForCompletionAsync(async ct =>
                 {
-                    WaitUntil = WaitUntilState.Load
-                }).ConfigureAwait(false);
+                    navigationResponse = await tab.Page.GoBackAsync(new PageGoBackOptions
+                    {
+                        WaitUntil = WaitUntilState.Load
+                    }).ConfigureAwait(false);
+                }, token).ConfigureAwait(false);
 
                 if (navigationResponse is null)
                 {


### PR DESCRIPTION
## Summary
- implement a TabState.WaitForCompletionAsync helper that mirrors the TypeScript settling logic and races modal states
- wrap tab-centric actions (form fill and go back) in the new helper to ensure page interactions settle before returning
- add regression coverage for outstanding requests, modal interruptions, and the post-action delay

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5c63732f48329b762d29d59ec5e37