### PR TITLE
Refresh tab titles for tab list responses

### DIFF
--- a/dotnet/PlaywrightMcpServer.Tests/ResponseTests.cs
+++ b/dotnet/PlaywrightMcpServer.Tests/ResponseTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using Moq;
+using Xunit;
+
+namespace PlaywrightMcpServer.Tests;
+
+public class ResponseTests
+{
+    [Fact]
+    public async Task FinishAsync_UpdatesTabTitlesWhenTabsRequested()
+    {
+        var tabManager = new TabManager();
+        var snapshotManager = new SnapshotManager();
+        var responseContext = new ResponseContext(tabManager, snapshotManager, new ResponseConfiguration());
+
+        var pageMock = new Mock<IPage>();
+        pageMock.SetupGet(p => p.Url).Returns("about:blank");
+        pageMock.Setup(p => p.TitleAsync()).ReturnsAsync("Updated Title");
+        SetupPageEvents(pageMock);
+
+        var tab = tabManager.Register(pageMock.Object);
+        var response = new Response(responseContext, "tool", new Dictionary<string, object?>());
+        response.SetIncludeTabs();
+
+        await response.FinishAsync(CancellationToken.None).ConfigureAwait(false);
+
+        Assert.Equal("Updated Title", tab.Title);
+        pageMock.Verify(p => p.TitleAsync(), Times.Once);
+    }
+
+    private static void SetupPageEvents(Mock<IPage> pageMock)
+    {
+        pageMock.SetupAdd(p => p.Console += It.IsAny<EventHandler<IConsoleMessage>>());
+        pageMock.SetupRemove(p => p.Console -= It.IsAny<EventHandler<IConsoleMessage>>());
+        pageMock.SetupAdd(p => p.Request += It.IsAny<EventHandler<IRequest>>());
+        pageMock.SetupRemove(p => p.Request -= It.IsAny<EventHandler<IRequest>>());
+        pageMock.SetupAdd(p => p.Response += It.IsAny<EventHandler<IResponse>>());
+        pageMock.SetupRemove(p => p.Response -= It.IsAny<EventHandler<IResponse>>());
+        pageMock.SetupAdd(p => p.RequestFailed += It.IsAny<EventHandler<IRequest>>());
+        pageMock.SetupRemove(p => p.RequestFailed -= It.IsAny<EventHandler<IRequest>>());
+        pageMock.SetupAdd(p => p.Close += It.IsAny<EventHandler<IPage>>());
+        pageMock.SetupRemove(p => p.Close -= It.IsAny<EventHandler<IPage>>());
+        pageMock.SetupAdd(p => p.Dialog += It.IsAny<EventHandler<IDialog>>());
+        pageMock.SetupRemove(p => p.Dialog -= It.IsAny<EventHandler<IDialog>>());
+        pageMock.SetupAdd(p => p.FileChooser += It.IsAny<EventHandler<IFileChooser>>());
+        pageMock.SetupRemove(p => p.FileChooser -= It.IsAny<EventHandler<IFileChooser>>());
+        pageMock.SetupAdd(p => p.Download += It.IsAny<EventHandler<IDownload>>());
+        pageMock.SetupRemove(p => p.Download -= It.IsAny<EventHandler<IDownload>>());
+    }
+}

--- a/dotnet/PlaywrightMcpServer.Tests/TabStateTests.cs
+++ b/dotnet/PlaywrightMcpServer.Tests/TabStateTests.cs
@@ -53,6 +53,25 @@ public class TabStateTests
         Assert.Contains("Capture a new snapshot", exception.Message);
     }
 
+    [Fact]
+    public async Task CaptureSnapshotAsync_UpdatesMetadata()
+    {
+        var pageMock = new Mock<IPage>();
+        pageMock.Setup(p => p.TitleAsync()).ReturnsAsync("Snapshot Title");
+        pageMock.SetupGet(p => p.Url).Returns("https://example.com/");
+
+        var tab = new TabState(pageMock.Object, "tab-1", DateTimeOffset.UtcNow, _ => { });
+        var snapshotManager = new SnapshotManager();
+
+        var snapshot = await tab.CaptureSnapshotAsync(snapshotManager, CancellationToken.None).ConfigureAwait(false);
+
+        Assert.Equal("https://example.com/", tab.Url);
+        Assert.Equal("Snapshot Title", tab.Title);
+        Assert.Same(snapshot, tab.LastSnapshot);
+        Assert.Equal("Snapshot Title", snapshot.Title);
+        Assert.Equal("https://example.com/", snapshot.Url);
+    }
+
     private static Mock<IPage> CreatePageMock(string snapshot, out Dictionary<string, Mock<ILocator>> locatorMap)
     {
         locatorMap = new Dictionary<string, Mock<ILocator>>(StringComparer.Ordinal)

--- a/dotnet/Response.cs
+++ b/dotnet/Response.cs
@@ -81,6 +81,14 @@ public sealed class Response
         {
             _snapshot = await _context.CaptureSnapshotAsync(_context.CurrentTab, cancellationToken).ConfigureAwait(false);
         }
+
+        if (_includeTabs)
+        {
+            foreach (var tab in _context.Tabs)
+            {
+                await tab.UpdateTitleAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
     }
 
     public SerializedResponse Serialize(ResponseSerializationOptions? options = null)

--- a/dotnet/TabManager.cs
+++ b/dotnet/TabManager.cs
@@ -271,6 +271,27 @@ internal sealed class TabState : IDisposable
 
     internal readonly record struct RefLocatorRequest(string ElementDescription, string Reference);
 
+    internal async Task UpdateTitleAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        string? title = null;
+        var modalStates = await RaceAgainstModalStatesAsync(async _ =>
+        {
+            title = await Page.TitleAsync().ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
+
+        if (modalStates.Count > 0 || title is null)
+        {
+            return;
+        }
+
+        lock (_gate)
+        {
+            Title = title;
+        }
+    }
+
     public void AttachHandlers()
     {
         Page.Console += _consoleHandler;


### PR DESCRIPTION
## Summary
- add an UpdateTitleAsync helper on TabState that re-queries the Playwright page title while racing modal states
- call the new helper for every tab when finishing a response that includes the tab list so stored titles stay current
- extend unit coverage to ensure snapshot capture maintains metadata and tab listings refresh their titles without a snapshot

## Testing
- dotnet test dotnet/PlaywrightMcpServer.Tests/PlaywrightMcpServer.Tests.csproj *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5cd12ed3483299d65c9f13e1aa2db