### PR TITLE
Implement browser console log tool

### DIFF
--- a/dotnet/PlaywrightTools.Actions.Console.cs
+++ b/dotnet/PlaywrightTools.Actions.Console.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,12 +15,31 @@ public sealed partial class PlaywrightTools
         [Description("Only return error messages.")] bool? onlyErrors = null,
         CancellationToken cancellationToken = default)
     {
-        // TODO: Implement tool logic for retrieving console messages from the page.
-        // Pseudocode:
-        // 1. Gather console entries emitted by the page since load.
-        // 2. Filter messages when onlyErrors is requested.
-        // 3. Return the collected console output in serialized form.
-        await Task.CompletedTask;
-        throw new NotImplementedException();
+        var args = new Dictionary<string, object?>(StringComparer.Ordinal);
+        if (onlyErrors.HasValue)
+        {
+            args["onlyErrors"] = onlyErrors.Value;
+        }
+
+        return await ExecuteWithResponseAsync(
+            "browser_console_messages",
+            args,
+            async (response, token) =>
+            {
+                var tab = await GetActiveTabAsync(token).ConfigureAwait(false);
+                var messages = tab.GetConsoleMessages(onlyErrors.GetValueOrDefault());
+
+                if (messages.Count == 0)
+                {
+                    response.AddResult(onlyErrors.GetValueOrDefault()
+                        ? "No error console messages."
+                        : "No console messages.");
+                }
+                else
+                {
+                    response.AddResult(Serialize(messages));
+                }
+            },
+            cancellationToken).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
## Summary
- add a TabState.GetConsoleMessages API that filters error messages and tracks recent console output
- implement the browser_console_messages tool to serialize console logs via the new API
- add unit tests covering complete and error-only console log retrieval

## Testing
- `dotnet test` *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5d1a2335883298493940bd5db55c8