### PR TITLE
Add tab lookup and modal helpers

### DIFF
--- a/dotnet/ModalStateMarkdownBuilder.cs
+++ b/dotnet/ModalStateMarkdownBuilder.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace PlaywrightMcpServer;
+
+internal static class ModalStateMarkdownBuilder
+{
+    public static IReadOnlyList<string> Build(IReadOnlyList<ModalStateEntry> modalStates)
+    {
+        var lines = new List<string> { "### Modal state" };
+
+        if (modalStates.Count == 0)
+        {
+            lines.Add("- There is no modal state present");
+            return lines;
+        }
+
+        foreach (var state in modalStates)
+        {
+            lines.Add($"- [{state.Description}]: can be handled by the \"{state.ClearedBy}\" tool");
+        }
+
+        return lines;
+    }
+}

--- a/dotnet/PlaywrightMcpServer.Tests/PlaywrightMcpServer.Tests.csproj
+++ b/dotnet/PlaywrightMcpServer.Tests/PlaywrightMcpServer.Tests.csproj
@@ -20,6 +20,7 @@
     <Compile Include="../SecretRedactor.cs" />
     <Compile Include="../SnapshotMarkdownBuilder.cs" />
     <Compile Include="../SnapshotManager.cs" />
+    <Compile Include="../ModalStateMarkdownBuilder.cs" />
     <Compile Include="../TabManager.cs" />
   </ItemGroup>
 </Project>

--- a/dotnet/PlaywrightMcpServer.Tests/TabManagerTests.cs
+++ b/dotnet/PlaywrightMcpServer.Tests/TabManagerTests.cs
@@ -1,0 +1,74 @@
+using System;
+using Microsoft.Playwright;
+using Moq;
+using Xunit;
+
+namespace PlaywrightMcpServer.Tests;
+
+public class TabManagerTests
+{
+    [Fact]
+    public void ForPage_ReturnsRegisteredTab()
+    {
+        var manager = new TabManager();
+        var pageMock = new Mock<IPage>();
+
+        var tab = manager.Register(pageMock.Object);
+
+        var result = manager.ForPage(pageMock.Object);
+
+        Assert.Same(tab, result);
+    }
+
+    [Fact]
+    public void ForPage_ReturnsNullForUnknownPage()
+    {
+        var manager = new TabManager();
+        var pageMock = new Mock<IPage>();
+
+        var result = manager.ForPage(pageMock.Object);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void CollectConsoleMessages_ReturnsMessagesForPage()
+    {
+        var manager = new TabManager();
+        var pageMock = new Mock<IPage>();
+        pageMock.SetupGet(p => p.Url).Returns("https://example.com/");
+
+        var tab = manager.Register(pageMock.Object);
+
+        var message = CreateConsoleMessage("error", "Something went wrong");
+        pageMock.Raise(p => p.Console += null!, message.Object);
+
+        var messages = manager.CollectConsoleMessages(pageMock.Object);
+
+        var entry = Assert.Single(messages);
+        Assert.Equal("error", entry.Type);
+        Assert.Equal("Something went wrong", entry.Text);
+
+        tab.Dispose();
+    }
+
+    [Fact]
+    public void CollectConsoleMessages_ReturnsEmptyForUnknownPage()
+    {
+        var manager = new TabManager();
+        var pageMock = new Mock<IPage>();
+
+        var messages = manager.CollectConsoleMessages(pageMock.Object);
+
+        Assert.Empty(messages);
+    }
+
+    private static Mock<IConsoleMessage> CreateConsoleMessage(string type, string text)
+    {
+        var message = new Mock<IConsoleMessage>();
+        message.SetupGet(m => m.Type).Returns(type);
+        message.SetupGet(m => m.Text).Returns(text);
+        message.Setup(m => m.Args).Returns(Array.Empty<IJSHandle>());
+        return message;
+    }
+}

--- a/dotnet/SnapshotMarkdownBuilder.cs
+++ b/dotnet/SnapshotMarkdownBuilder.cs
@@ -12,19 +12,7 @@ internal static class SnapshotMarkdownBuilder
 
         if (snapshot.ModalStates is { } modalStates)
         {
-            lines.Add("### Modal state");
-            if (modalStates.Count == 0)
-            {
-                lines.Add("- There is no modal state present");
-            }
-            else
-            {
-                foreach (var state in modalStates)
-                {
-                    lines.Add($"- [{state.Description}]: can be handled by the \"{state.ClearedBy}\" tool");
-                }
-            }
-
+            lines.AddRange(ModalStateMarkdownBuilder.Build(modalStates));
             lines.Add(string.Empty);
         }
 


### PR DESCRIPTION
## Summary
- add helpers on TabManager to look up tabs by page and collect console messages
- expose modal markdown rendering and timeout waiting support on TabState with shared builder
- cover the new behavior with unit tests

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e5d744df588329a7269c0a6543da5d