### PR TITLE
Allow PlaywrightRemoteBrowserLauncher to attach to existing processes

### DIFF
--- a/PlaywrightRemoteBrowserLauncher/MainForm.Designer.cs
+++ b/PlaywrightRemoteBrowserLauncher/MainForm.Designer.cs
@@ -228,16 +228,16 @@ partial class MainForm
         btnLaunch.Location = new Point(14, 24);
         btnLaunch.Margin = new Padding(4);
         btnLaunch.Name = "btnLaunch";
-        btnLaunch.Size = new Size(95, 40);
+        btnLaunch.Size = new Size(120, 40);
         btnLaunch.TabIndex = 0;
-        btnLaunch.Text = "1-启动进程";
+        btnLaunch.Text = "1-启动/获取进程";
         btnLaunch.UseVisualStyleBackColor = true;
         btnLaunch.Click += btnLaunch_Click;
-        // 
+        //
         // btnWaitDevTools
-        // 
+        //
         btnWaitDevTools.Enabled = false;
-        btnWaitDevTools.Location = new Point(116, 24);
+        btnWaitDevTools.Location = new Point(138, 24);
         btnWaitDevTools.Margin = new Padding(4);
         btnWaitDevTools.Name = "btnWaitDevTools";
         btnWaitDevTools.Size = new Size(100, 40);
@@ -249,7 +249,7 @@ partial class MainForm
         // btnConnect
         // 
         btnConnect.Enabled = false;
-        btnConnect.Location = new Point(223, 24);
+        btnConnect.Location = new Point(242, 24);
         btnConnect.Margin = new Padding(4);
         btnConnect.Name = "btnConnect";
         btnConnect.Size = new Size(110, 40);
@@ -261,7 +261,7 @@ partial class MainForm
         // btnNewPage
         // 
         btnNewPage.Enabled = false;
-        btnNewPage.Location = new Point(340, 24);
+        btnNewPage.Location = new Point(356, 24);
         btnNewPage.Margin = new Padding(4);
         btnNewPage.Name = "btnNewPage";
         btnNewPage.Size = new Size(105, 40);
@@ -273,7 +273,7 @@ partial class MainForm
         // btnGoto
         // 
         btnGoto.Enabled = false;
-        btnGoto.Location = new Point(452, 24);
+        btnGoto.Location = new Point(465, 24);
         btnGoto.Margin = new Padding(4);
         btnGoto.Name = "btnGoto";
         btnGoto.Size = new Size(100, 40);
@@ -285,7 +285,7 @@ partial class MainForm
         // btnCloseAll
         // 
         btnCloseAll.Enabled = false;
-        btnCloseAll.Location = new Point(559, 24);
+        btnCloseAll.Location = new Point(569, 24);
         btnCloseAll.Margin = new Padding(4);
         btnCloseAll.Name = "btnCloseAll";
         btnCloseAll.Size = new Size(100, 40);

--- a/PlaywrightRemoteBrowserLauncher/MainForm.cs
+++ b/PlaywrightRemoteBrowserLauncher/MainForm.cs
@@ -1,7 +1,5 @@
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Net;
-using System.Net.Sockets;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using PlaywrightRemoteBrowserLauncher.Extensions;
@@ -98,16 +96,9 @@ public partial class MainForm : Form
                 numPort.Value = parsedPort;
             }
         }
-        var port = (int)numPort.Value;
-        if (!IsPortAvailable(port, out var portError))
-        {
-            AppendLog(portError ?? $"❌ 端口 {port} 当前不可用，请更换端口后重试。");
-            return;
-        }
-
         var started = _processLauncher.Start(
             commandLine,
-            port,
+            (int)numPort.Value,
             UserDataRoot,
             txtProxy.Text.Trim(),
             AppendLog);
@@ -116,29 +107,6 @@ public partial class MainForm : Form
         {
             btnWaitDevTools.Enabled = true;
             btnCloseAll.Enabled = true;
-        }
-    }
-
-    private static bool IsPortAvailable(int port, out string? errorMessage)
-    {
-        try
-        {
-            using var listener = new TcpListener(IPAddress.Loopback, port);
-            listener.Server.ExclusiveAddressUse = true;
-            listener.Start();
-            listener.Stop();
-            errorMessage = null;
-            return true;
-        }
-        catch (SocketException ex) when (ex.SocketErrorCode == SocketError.AddressAlreadyInUse)
-        {
-            errorMessage = $"❌ 端口 {port} 已被其他进程占用，请更换端口后重试。";
-            return false;
-        }
-        catch (Exception ex)
-        {
-            errorMessage = $"❌ 无法检测端口 {port} 是否可用：{ex.Message}";
-            return false;
         }
     }
 

--- a/PlaywrightRemoteBrowserLauncher/Services/BrowserProcessLauncher.cs
+++ b/PlaywrightRemoteBrowserLauncher/Services/BrowserProcessLauncher.cs
@@ -1,5 +1,9 @@
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
 using System.Text;
 
 namespace PlaywrightRemoteBrowserLauncher.Services;
@@ -7,6 +11,8 @@ namespace PlaywrightRemoteBrowserLauncher.Services;
 public sealed class BrowserProcessLauncher : IDisposable
 {
     private Process? _process;
+    private bool _ownsProcess;
+    private string? _processExecutablePath;
 
     public Process? Process => _process;
 
@@ -26,8 +32,33 @@ public sealed class BrowserProcessLauncher : IDisposable
             return false;
         }
 
-        Directory.CreateDirectory(userDataDir);
+        if (_process is { HasExited: false } &&
+            _processExecutablePath is not null &&
+            string.Equals(_processExecutablePath, executablePath, StringComparison.OrdinalIgnoreCase))
+        {
+            log($"进程已在运行 (PID {_process.Id})：{executablePath}");
+            return true;
+        }
+
         Stop();
+
+        var existingProcess = FindExistingProcess(executablePath);
+        if (existingProcess is not null)
+        {
+            _process = existingProcess;
+            _ownsProcess = false;
+            _processExecutablePath = executablePath;
+            log($"已获取现有进程 (PID {existingProcess.Id})：{executablePath}");
+            return true;
+        }
+
+        if (!IsPortAvailable(port, out var portError))
+        {
+            log(portError ?? $"❌ 端口 {port} 当前不可用，请更换端口后重试。");
+            return false;
+        }
+
+        Directory.CreateDirectory(userDataDir);
 
         var argsBuilder = new StringBuilder();
         var containsRemotePortArgument = false;
@@ -78,17 +109,20 @@ public sealed class BrowserProcessLauncher : IDisposable
             return false;
         }
 
-        log($"已启动：{executablePath}");
+        _ownsProcess = true;
+        _processExecutablePath = executablePath;
+        log($"已启动新进程 (PID {_process.Id})：{executablePath}");
         return true;
     }
 
     public void Stop()
     {
+        var process = _process;
         try
         {
-            if (_process is { HasExited: false })
+            if (process is { HasExited: false } && _ownsProcess)
             {
-                _process.Kill(true);
+                process.Kill(true);
             }
         }
         catch
@@ -98,6 +132,17 @@ public sealed class BrowserProcessLauncher : IDisposable
         finally
         {
             _process = null;
+            _processExecutablePath = null;
+            _ownsProcess = false;
+
+            try
+            {
+                process?.Dispose();
+            }
+            catch
+            {
+                // ignored
+            }
         }
     }
 
@@ -145,5 +190,85 @@ public sealed class BrowserProcessLauncher : IDisposable
         var executable = builder.ToString();
         var extraArguments = index < span.Length ? span[index..].ToString() : null;
         return (executable, string.IsNullOrWhiteSpace(extraArguments) ? null : extraArguments);
+    }
+
+    private static Process? FindExistingProcess(string executablePath)
+    {
+        if (string.IsNullOrWhiteSpace(executablePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            var processName = Path.GetFileNameWithoutExtension(executablePath);
+            if (string.IsNullOrWhiteSpace(processName))
+            {
+                return null;
+            }
+
+            var candidates = Process.GetProcessesByName(processName);
+            Process? matched = null;
+            foreach (var process in candidates)
+            {
+                try
+                {
+                    var path = process.MainModule?.FileName;
+                    if (!string.IsNullOrWhiteSpace(path) && process is { HasExited: false } &&
+                        string.Equals(path, executablePath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        matched = process;
+                        break;
+                    }
+                }
+                catch (Win32Exception)
+                {
+                    // ignore processes that cannot be inspected
+                }
+                catch (InvalidOperationException)
+                {
+                    // process exited during inspection
+                }
+            }
+
+            foreach (var process in candidates)
+            {
+                if (!ReferenceEquals(process, matched))
+                {
+                    process.Dispose();
+                }
+            }
+
+            return matched;
+        }
+        catch (Exception)
+        {
+            // ignore errors when searching for existing processes
+        }
+
+        return null;
+    }
+
+    private static bool IsPortAvailable(int port, out string? errorMessage)
+    {
+        try
+        {
+            using var listener = new TcpListener(IPAddress.Loopback, port);
+            listener.Server.ExclusiveAddressUse = true;
+            listener.Start();
+            listener.Stop();
+            errorMessage = null;
+            return true;
+        }
+        catch (SocketException ex) when (ex.SocketErrorCode == SocketError.AddressAlreadyInUse)
+        {
+            errorMessage = $"❌ 端口 {port} 已被其他进程占用，请更换端口后重试。";
+            return false;
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"❌ 无法检测端口 {port} 是否可用：{ex.Message}";
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow the browser launcher to reuse an already running process when possible before starting a new instance
- move the port availability check into the launcher and keep ownership state so externally started processes are not terminated
- refresh the launch button text/layout to reflect the new start-or-attach workflow

## Testing
- dotnet build PlaywrightDotnetMcp.sln *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f8a2a4a8dc832997df729c00b90b42

## Sourcery 摘要

通过重用现有浏览器进程、将端口检查集中到启动器中，并刷新 UI 以支持新行为，启用启动或附加工作流。

新功能:
- 允许 BrowserProcessLauncher 通过可执行文件路径附加到已运行的浏览器进程，而不是总是启动一个新的。

增强功能:
- 跟踪进程所有权以避免终止外部启动的浏览器，并将端口可用性检查从 UI 移到启动器中。
- 添加 FindExistingProcess 和 IsPortAvailable 辅助函数，用于进程检测和端口验证。
- 更新启动按钮文本并调整 UI 控件布局，以反映组合的启动或附加工作流，并从表单中删除冗余的端口检查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable start-or-attach workflow by reusing existing browser processes, centralizing port checks in the launcher, and refreshing the UI to support the new behavior.

New Features:
- Allow BrowserProcessLauncher to attach to an already running browser process by executable path instead of always starting a new one.

Enhancements:
- Track process ownership to avoid terminating externally launched browsers and move port availability checks from the UI into the launcher.
- Add FindExistingProcess and IsPortAvailable helpers for process detection and port validation.
- Update the launch button text and adjust UI control layouts to reflect the combined start-or-attach workflow and remove redundant port checks from the form.

</details>